### PR TITLE
feat: added validators module cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# cache
+cache

--- a/src/jobs/validators/validators.service.ts
+++ b/src/jobs/validators/validators.service.ts
@@ -14,6 +14,7 @@ import { unblock } from '../../common/utils/unblock';
 import { LidoKeysService } from './lido-keys';
 import { ResponseValidatorsData, Validator } from './validators.types';
 import { parseGweiToWei } from '../../common/utils/parse-gwei-to-big-number';
+import { ValidatorsCacheService } from 'storage/validators/validators-cache.service';
 
 export class ValidatorsService {
   constructor(
@@ -23,6 +24,7 @@ export class ValidatorsService {
     protected readonly configService: ConfigService,
     protected readonly jobService: JobService,
     protected readonly validatorsStorageService: ValidatorsStorageService,
+    protected readonly validatorsCacheService: ValidatorsCacheService,
     protected readonly genesisTimeService: GenesisTimeService,
     protected readonly lidoKeys: LidoKeysService,
   ) {}
@@ -31,6 +33,7 @@ export class ValidatorsService {
    * Initializes the job
    */
   public async initialize(): Promise<void> {
+    await this.validatorsCacheService.initializeFromCache();
     await this.updateValidators();
 
     const cronTime = this.configService.get('JOB_INTERVAL_VALIDATORS');
@@ -71,6 +74,8 @@ export class ValidatorsService {
       this.validatorsStorageService.setTotal(totalValidators);
       this.validatorsStorageService.setMaxExitEpoch(latestEpoch);
       this.validatorsStorageService.setLastUpdate(Math.floor(Date.now() / 1000));
+
+      await this.validatorsCacheService.saveDataToCache();
 
       this.logger.log('End update validators', { service: 'validators', totalValidators, latestEpoch });
     });

--- a/src/storage/validators/index.ts
+++ b/src/storage/validators/index.ts
@@ -1,2 +1,3 @@
 export * from './validators.module';
 export * from './validators.service';
+export * from './validators-cache.service';

--- a/src/storage/validators/validators-cache.service.ts
+++ b/src/storage/validators/validators-cache.service.ts
@@ -1,0 +1,103 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { mkdir, open, writeFile } from 'node:fs/promises';
+import * as path from 'path';
+import { LOGGER_PROVIDER, LoggerService } from '../../common/logger';
+import { ValidatorsStorageService } from './validators.service';
+import { BigNumber } from '@ethersproject/bignumber';
+import { parseEther } from '@ethersproject/units';
+
+@Injectable()
+export class ValidatorsCacheService {
+  static CACHE_FILE_NAME = 'validators-state.txt';
+  static CACHE_DIR = 'cache';
+  static CACHE_DATA_DIVIDER = '|';
+  static SERVICE_LOG_NAME = 'validators cache';
+  static CACHE_INVALIDATE_TIME = 3 * 3600; // 3 hours
+
+  constructor(
+    @Inject(LOGGER_PROVIDER) protected readonly logger: LoggerService,
+    protected readonly validatorsStorage: ValidatorsStorageService,
+  ) {}
+
+  public async initializeFromCache() {
+    const cacheFileName = this.getCacheFileName();
+    try {
+      this.logger.log(`try initialize from cache file ${cacheFileName}`, {
+        service: ValidatorsCacheService.SERVICE_LOG_NAME,
+      });
+      const file = await open(cacheFileName);
+      const fileReadResult = await file.readFile({ encoding: 'utf-8' });
+      await file.close();
+      const data: string[] = fileReadResult.split(ValidatorsCacheService.CACHE_DATA_DIVIDER);
+
+      if (data.length !== 4) {
+        this.logger.log(`invalid cache data length`, {
+          service: ValidatorsCacheService.SERVICE_LOG_NAME,
+          data,
+        });
+        return;
+      }
+
+      const lastUpdate = Number(data[2]);
+      const now = Math.floor(Date.now() / 1000);
+      const isDataValid = now - lastUpdate < ValidatorsCacheService.CACHE_INVALIDATE_TIME;
+
+      if (!isDataValid) {
+        this.logger.log(`found outdated cache, skip initialization from cache`, {
+          service: ValidatorsCacheService.SERVICE_LOG_NAME,
+          data,
+        });
+        return;
+      }
+
+      this.validatorsStorage.setTotal(Number(data[0]));
+      this.validatorsStorage.setMaxExitEpoch(data[1]);
+      this.validatorsStorage.setLastUpdate(Number(data[2]));
+      this.validatorsStorage.setFrameBalances(this.parseFrameBalances(data[3]));
+
+      this.logger.log(`success initialize from cache file ${cacheFileName}`, {
+        service: ValidatorsCacheService.SERVICE_LOG_NAME,
+        data,
+      });
+    } catch (e) {
+      this.logger.error(e, { service: ValidatorsCacheService.SERVICE_LOG_NAME });
+      this.logger.log(`failed to initialize from file ${cacheFileName}`, {
+        service: ValidatorsCacheService.SERVICE_LOG_NAME,
+      });
+    }
+  }
+
+  public async saveDataToCache() {
+    const cacheFileName = this.getCacheFileName();
+    this.logger.log(`try save to file ${cacheFileName}`, { service: ValidatorsCacheService.SERVICE_LOG_NAME });
+
+    await mkdir(ValidatorsCacheService.CACHE_DIR, { recursive: true });
+    const data = [
+      this.validatorsStorage.getTotal(),
+      this.validatorsStorage.getMaxExitEpoch(),
+      this.validatorsStorage.getLastUpdate(),
+      this.stringifyFrameBalances(this.validatorsStorage.getFrameBalances()),
+    ].join(ValidatorsCacheService.CACHE_DATA_DIVIDER);
+    await writeFile(cacheFileName, data);
+    this.logger.log(`success save to file ${cacheFileName}`, { service: ValidatorsCacheService.SERVICE_LOG_NAME });
+  }
+
+  protected getCacheFileName = () => {
+    return path.join(ValidatorsCacheService.CACHE_DIR, ValidatorsCacheService.CACHE_FILE_NAME);
+  };
+
+  protected stringifyFrameBalances(frameBalances: Record<string, BigNumber>) {
+    return JSON.stringify(
+      Object.keys(frameBalances).reduce((acc, key) => {
+        return { ...acc, [key]: frameBalances[key].toString() };
+      }, {}),
+    );
+  }
+
+  protected parseFrameBalances(frameBalancesStr: string) {
+    const frameBalances = JSON.parse(frameBalancesStr);
+    return Object.keys(frameBalances).reduce((acc, key) => {
+      return { ...acc, [key]: parseEther(frameBalances[key]) };
+    }, {});
+  }
+}

--- a/src/storage/validators/validators.module.ts
+++ b/src/storage/validators/validators.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ValidatorsStorageService } from './validators.service';
+import { ValidatorsCacheService } from './validators-cache.service';
 
 @Module({
-  providers: [ValidatorsStorageService],
-  exports: [ValidatorsStorageService],
+  providers: [ValidatorsStorageService, ValidatorsCacheService],
+  exports: [ValidatorsStorageService, ValidatorsCacheService],
 })
 export class ValidatorsStorageModule {}


### PR DESCRIPTION
### Changes:
- added cache service for validators data

### Review notes
- cache service creates file `cache/validators-state.txt` with all data
- cache validation: checks lengths of items in cache (should be equal 4), check last update date was less then 3 hours ago
- initialisation from cache happens automatically on server start if cache exists and is validate
- cache is update on each cron iteration, each 3 hours

### Before merge:
- make sure that devops setup role for creating `cache` folder