### PR TITLE
feat: added envs logs and metrics, added health check on start

### DIFF
--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -96,3 +96,21 @@ export function validate(config: Record<string, unknown>) {
 
   return validatedConfig;
 }
+
+export const ENV_KEYS = [
+  'NODE_ENV',
+  'PORT',
+  'CORS_WHITELIST_REGEXP',
+  'GLOBAL_THROTTLE_TTL',
+  'GLOBAL_THROTTLE_LIMIT',
+  'GLOBAL_CACHE_TTL',
+  'SENTRY_DSN',
+  'LOG_LEVEL',
+  'LOG_FORMAT',
+  'JOB_INTERVAL_VALIDATORS',
+  'JOB_INTERVAL_QUEUE_INFO',
+  'JOB_INTERVAL_CONTRACT_CONFIG',
+  'CL_API_URLS',
+  'EL_RPC_URLS',
+  'CHAIN_ID',
+];

--- a/src/common/health/health.module.ts
+++ b/src/common/health/health.module.ts
@@ -1,13 +1,34 @@
-import { Module } from '@nestjs/common';
+import { Inject, LoggerService, Module, OnModuleInit } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HealthController } from './health.controller';
 import { ExecutionProviderHealthIndicator } from './execution-provider.indicator';
 import { ConsensusProviderIndicator } from './consensus-provider.indicator';
 import { GenesisTimeModule } from '../genesis-time';
+import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
 
 @Module({
   providers: [ExecutionProviderHealthIndicator, ConsensusProviderIndicator],
   controllers: [HealthController],
   imports: [TerminusModule, GenesisTimeModule],
 })
-export class HealthModule {}
+export class HealthModule implements OnModuleInit {
+  constructor(
+    @Inject(LOGGER_PROVIDER) protected readonly logger: LoggerService,
+    protected readonly consensusProviderIndicator: ConsensusProviderIndicator,
+    protected readonly executionProviderIndicator: ExecutionProviderHealthIndicator,
+  ) {}
+
+  async onModuleInit() {
+    await this.startUpChecks();
+  }
+
+  async startUpChecks() {
+    try {
+      await this.consensusProviderIndicator.isHealthy('consensusProvider');
+      await this.executionProviderIndicator.isHealthy('executionProvider');
+      this.logger.log(`Start up checks passed successfully`);
+    } catch (e) {
+      this.logger.error(`Start up checks failed with error: ${e}`);
+    }
+  }
+}

--- a/src/common/prometheus/prometheus.service.ts
+++ b/src/common/prometheus/prometheus.service.ts
@@ -2,6 +2,7 @@ import { getOrCreateMetric } from '@willsoto/nestjs-prometheus';
 import { Options, Metrics, Metric } from './interfaces';
 import { METRICS_PREFIX } from './prometheus.constants';
 import { RequestSourceType } from '../../http/request-time/headers/request-source-type';
+import { ENV_KEYS } from '../config';
 
 export class PrometheusService {
   protected prefix = METRICS_PREFIX;
@@ -25,7 +26,13 @@ export class PrometheusService {
   public buildInfo = this.getOrCreateMetric('Gauge', {
     name: 'build_info',
     help: 'Build information',
-    labelNames: ['name', 'version', 'env', 'network', 'startSlot'],
+    labelNames: ['name', 'version', 'env', 'network'],
+  });
+
+  public envsInfo = this.getOrCreateMetric('Gauge', {
+    name: 'envs_info',
+    help: 'Environment variables information',
+    labelNames: ENV_KEYS,
   });
 
   public clApiRequestDuration = this.getOrCreateMetric('Histogram', {

--- a/src/http/common/middleware/logger.middleware.ts
+++ b/src/http/common/middleware/logger.middleware.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable, LoggerService, NestMiddleware } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { Request, Reply } from './interfaces';
-import { FastifyRequest } from 'fastify';
 
 @Injectable()
 export class LoggerMiddleware implements NestMiddleware {
@@ -10,15 +9,13 @@ export class LoggerMiddleware implements NestMiddleware {
     private readonly logger: LoggerService,
   ) {}
 
-  use(request: any, reply: Reply, next: () => void) {
+  use(request: Request, reply: Reply, next: () => void) {
     const { ip, method, headers, originalUrl } = request;
     const userAgent = headers['user-agent'] ?? '';
 
-    const ips = request.ips ? request.ips : [];
-
     reply.on('finish', () => {
       const { statusCode } = reply;
-      const log = { method, originalUrl, statusCode, userAgent, ip, ips };
+      const log = { method, originalUrl, statusCode, userAgent, ip };
 
       this.logger.log(JSON.stringify(log));
     });


### PR DESCRIPTION
### Description
- added log of environment variables on start app
- added environment variables into prometheus
- added health check on start app

### Demo
Now prometheus metrics contains all envs, but we can change if some of them are not needed.

```
# HELP envs_info Environment variables information
# TYPE envs_info gauge
envs_info{NODE_ENV="development",PORT="3001",CORS_WHITELIST_REGEXP="^.*$$",GLOBAL_THROTTLE_TTL="5",GLOBAL_THROTTLE_LIMIT="100",GLOBAL_CACHE_TTL="1",SENTRY_DSN="",LOG_LEVEL="debug",LOG_FORMAT="json",JOB_INTERVAL_VALIDATORS="0 0/1 * * *",JOB_INTERVAL_QUEUE_INFO="0 */5 * * * *",JOB_INTERVAL_CONTRACT_CONFIG="0 0-23/10 * * *",CL_API_URLS="https://lido-4-cl.rpc.p2p.world/***********************************,https://lido-4-cl.rpc.p2p.world/************************************",EL_RPC_URLS="https://eth-mainnet.g.alchemy.com/v2/*************************
```
### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
