### PR TITLE
fix: fixed initialization server

### DIFF
--- a/src/http/validators/validators.service.ts
+++ b/src/http/validators/validators.service.ts
@@ -23,6 +23,10 @@ export class ValidatorsService {
       return acc;
     }, {} as Record<string, string>);
 
+    if (!lastUpdatedAt) {
+      return null;
+    }
+
     return {
       lastUpdatedAt,
       maxExitEpoch,

--- a/src/jobs/validators/validators.service.ts
+++ b/src/jobs/validators/validators.service.ts
@@ -88,7 +88,6 @@ export class ValidatorsService {
         this.validatorsStorageService.setActiveValidatorsCount(activeValidatorCount);
         this.validatorsStorageService.setTotalValidatorsCount(data.length);
         this.validatorsStorageService.setMaxExitEpoch(latestEpoch);
-        this.validatorsStorageService.setLastUpdate(Math.floor(Date.now() / 1000));
 
         const frameBalances = await this.getLidoValidatorsWithdrawableBalances(data);
         this.validatorsStorageService.setFrameBalances(frameBalances);
@@ -111,6 +110,8 @@ export class ValidatorsService {
             })
             .inc();
         });
+
+        this.validatorsStorageService.setLastUpdate(Math.floor(Date.now() / 1000));
       },
     );
   }

--- a/src/storage/validators/validators-cache.service.ts
+++ b/src/storage/validators/validators-cache.service.ts
@@ -52,8 +52,8 @@ export class ValidatorsCacheService {
 
       this.validatorsStorage.setActiveValidatorsCount(Number(data[0]));
       this.validatorsStorage.setMaxExitEpoch(data[1]);
-      this.validatorsStorage.setLastUpdate(Number(data[2]));
       this.validatorsStorage.setFrameBalances(this.parseFrameBalances(data[3]));
+      this.validatorsStorage.setLastUpdate(Number(data[2]));
 
       this.logger.log(`success initialize from cache file ${cacheFileName}`, {
         service: ValidatorsCacheService.SERVICE_LOG_NAME,


### PR DESCRIPTION
### Description

- fixed initialisation error happening because of wrong order setting `setLastUpdate` time


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
