### PR TITLE
fix: docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ WORKDIR /app
 
 COPY --from=building /app/dist ./dist
 COPY --from=building /app/node_modules ./node_modules
+COPY ./network-configs ./network-configs
 COPY ./package.json ./
 
 USER node


### PR DESCRIPTION
### Description

fix docker run when CUSTOM_NETWORK_FILE_NAME ENV was set

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
