### PR TITLE
fix: added warning frames, fixed past time fallback

### DIFF
--- a/src/waiting-time/waiting-time.service.ts
+++ b/src/waiting-time/waiting-time.service.ts
@@ -357,8 +357,9 @@ export class WaitingTimeService {
       currentType = recalculatedResult.type;
     }
 
+    const isInPastFallback = requestTimestamp + ms - Date.now() < 0;
     // temporary fallback for negative results, can be deleted after validator balances computation improvements
-    if (ms < 0) {
+    if (isInPastFallback) {
       this.logger.warn(
         `Request with id ${request.id} was recalculated and finalisation still in past (recalculated finalizationIn=${ms}). Fallback to next frame`,
       );


### PR DESCRIPTION
### Description

- added warning log frame balances
- fixed past time fallback

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
