### PR TITLE
feat: added lock on processing ref slot if processing started

### DIFF
--- a/src/common/genesis-time/genesis-time.service.ts
+++ b/src/common/genesis-time/genesis-time.service.ts
@@ -90,5 +90,10 @@ export class GenesisTimeService implements OnModuleInit {
     return Math.floor(this.getSlotByTimestamp(timestamp) / SLOTS_PER_EPOCH);
   }
 
+  async getBlockBySlot(slot: number) {
+    const block = await this.consensusService.getBlockV2({ blockId: `${slot}` });
+    return Number((block.data as any).message.body.execution_payload.block_number);
+  }
+
   protected genesisTime = -1;
 }

--- a/src/common/sweep/sweep.service.ts
+++ b/src/common/sweep/sweep.service.ts
@@ -1,6 +1,6 @@
-import { ethers } from 'ethers';
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
+import { LIDO_LOCATOR_CONTRACT_TOKEN, LidoLocator } from '@lido-nestjs/contracts';
 import { ConfigService } from 'common/config';
 import {
   isFullyWithdrawableValidator,
@@ -19,7 +19,7 @@ import {
   MIN_ACTIVATION_BALANCE,
 } from 'waiting-time/waiting-time.constants';
 import { Withdrawal } from './sweep.types';
-import { LIDO_LOCATOR_CONTRACT_TOKEN, LidoLocator } from '@lido-nestjs/contracts';
+import { ExecutionProvider } from '../execution-provider';
 
 @Injectable()
 export class SweepService {
@@ -30,13 +30,13 @@ export class SweepService {
     @Inject(LIDO_LOCATOR_CONTRACT_TOKEN) protected readonly lidoLocator: LidoLocator,
     protected readonly consensusClientService: ConsensusClientService,
     protected readonly configService: ConfigService,
+    protected readonly provider: ExecutionProvider,
   ) {}
 
   async getConsensusVersion() {
-    const provider = new ethers.JsonRpcProvider(this.configService.get('EL_RPC_URLS')[0]);
     const address = await this.lidoLocator.validatorsExitBusOracle();
     const validatorExitBusOracle = OracleV2__factory.connect(address, {
-      provider,
+      provider: this.provider as any,
     });
 
     return await validatorExitBusOracle.getConsensusVersion();

--- a/src/http/request-time/request-time.service.ts
+++ b/src/http/request-time/request-time.service.ts
@@ -22,7 +22,7 @@ export class RequestTimeService {
 
   async getRequestTime(params: RequestTimeOptionsDto): Promise<RequestTimeDto | null> {
     const isInitializing = this.waitingTimeService.checkIsInitializing();
-    if (!isInitializing) {
+    if (isInitializing) {
       return {
         status: WaitingTimeStatus.initializing,
       };

--- a/src/jobs/queue-info/queue-info.service.ts
+++ b/src/jobs/queue-info/queue-info.service.ts
@@ -7,7 +7,7 @@ import { OneAtTime } from '@lido-nestjs/decorators';
 import { QueueInfoStorageService } from 'storage';
 import { WithdrawalQueue, Lido, WITHDRAWAL_QUEUE_CONTRACT_TOKEN, LIDO_CONTRACT_TOKEN } from '@lido-nestjs/contracts';
 import { SimpleFallbackJsonRpcBatchProvider } from '@lido-nestjs/execution';
-import { WithdrawalRequest } from '../../storage/queue-info/queue-info.types';
+import { WithdrawalRequest } from 'storage/queue-info/queue-info.types';
 
 @Injectable()
 export class QueueInfoService {
@@ -34,16 +34,16 @@ export class QueueInfoService {
       return;
     }
 
+    const cronTime = this.configService.get('JOB_INTERVAL_QUEUE_INFO');
+    this.job = new CronJob(cronTime, () => this.updateQueueInfo());
+
+    this.job.start();
+
     try {
       await this.updateQueueInfo();
     } catch (error) {
       this.logger.error(error);
     }
-
-    const cronTime = this.configService.get('JOB_INTERVAL_QUEUE_INFO');
-    this.job = new CronJob(cronTime, () => this.updateQueueInfo());
-
-    this.job.start();
 
     this.logger.log('Service initialized', { service: QueueInfoService.SERVICE_LOG_NAME, cronTime });
   }

--- a/src/waiting-time/waiting-time.service.spec.ts
+++ b/src/waiting-time/waiting-time.service.spec.ts
@@ -8,7 +8,11 @@ import {
 } from 'storage';
 import { WaitingTimeService } from './waiting-time.service';
 import { BigNumber } from '@ethersproject/bignumber';
-import { LIDO_CONTRACT_TOKEN, WITHDRAWAL_QUEUE_CONTRACT_TOKEN } from '@lido-nestjs/contracts';
+import {
+  LIDO_CONTRACT_TOKEN,
+  LIDO_LOCATOR_CONTRACT_TOKEN,
+  WITHDRAWAL_QUEUE_CONTRACT_TOKEN,
+} from '@lido-nestjs/contracts';
 import { GenesisTimeService } from 'common/genesis-time/genesis-time.service';
 import { RewardsService } from 'events/rewards/rewards.service';
 import { SECONDS_PER_SLOT, SLOTS_PER_EPOCH } from 'common/genesis-time';
@@ -94,6 +98,10 @@ describe('WaitingTimeService', () => {
             getBufferedEther: jest.fn(),
             getDepositableEther: jest.fn(),
           },
+        },
+        {
+          provide: LIDO_LOCATOR_CONTRACT_TOKEN,
+          useValue: {},
         },
         {
           provide: RewardsStorageService,

--- a/src/waiting-time/waiting-time.service.ts
+++ b/src/waiting-time/waiting-time.service.ts
@@ -1,6 +1,13 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { BigNumber } from '@ethersproject/bignumber';
-import { LIDO_CONTRACT_TOKEN, Lido, WITHDRAWAL_QUEUE_CONTRACT_TOKEN, WithdrawalQueue } from '@lido-nestjs/contracts';
+import {
+  LIDO_CONTRACT_TOKEN,
+  Lido,
+  WITHDRAWAL_QUEUE_CONTRACT_TOKEN,
+  WithdrawalQueue,
+  LIDO_LOCATOR_CONTRACT_TOKEN,
+  LidoLocator,
+} from '@lido-nestjs/contracts';
 import { parseEther } from 'ethers';
 
 import {
@@ -41,6 +48,7 @@ import {
 import { SimpleFallbackJsonRpcBatchProvider } from '@lido-nestjs/execution';
 import { toEth } from '../common/utils/to-eth';
 import { MAX_SEED_LOOKAHEAD } from '../jobs/validators';
+import { OracleV2__factory } from '../common/contracts/generated';
 
 @Injectable()
 export class WaitingTimeService {
@@ -56,6 +64,7 @@ export class WaitingTimeService {
     protected readonly queueInfo: QueueInfoStorageService,
     protected readonly provider: SimpleFallbackJsonRpcBatchProvider,
     protected readonly prometheusService: PrometheusService,
+    @Inject(LIDO_LOCATOR_CONTRACT_TOKEN) protected readonly lidoLocator: LidoLocator,
   ) {}
 
   // preparing all needed number for calculation withdrawal time
@@ -72,8 +81,7 @@ export class WaitingTimeService {
 
     // nextCalculationAt not needed anymore due to runtime queries to contract
     const nextCalculationAt = this.queueInfo.getNextUpdate().toISOString();
-    const block = await this.provider.getBlock('safe');
-    const blockNumber = block.number;
+    const blockNumber = await this.getLatestOrBlockProcessingRefSlot();
 
     const [unfinalized, buffer, vaultsBalance] = !cached
       ? await Promise.all([
@@ -302,8 +310,7 @@ export class WaitingTimeService {
   }
 
   public async calculateRequestsTime(ids: string[]) {
-    const block = await this.provider.getBlock('safe');
-    const blockNumber = block.number;
+    const blockNumber = await this.getLatestOrBlockProcessingRefSlot();
 
     const [unfinalized, buffer, vaultsBalance] = await Promise.all([
       this.contractWithdrawal.unfinalizedStETH({ blockTag: blockNumber }),
@@ -501,5 +508,27 @@ export class WaitingTimeService {
     const currentEpoch = this.genesisTimeService.getCurrentEpoch();
 
     return Math.max(+maxExitEpoch, currentEpoch + MAX_SEED_LOOKAHEAD + 1);
+  }
+
+  // returns block of processing ref lost or latest block if ref lost in future
+  async getLatestOrBlockProcessingRefSlot() {
+    const address = await this.lidoLocator.accountingOracle();
+    const accountingOracle = OracleV2__factory.connect(address, {
+      provider: this.provider as any,
+    });
+
+    const processingState = await accountingOracle.getProcessingState();
+    const currentFrameRefSlot = Number(processingState.currentFrameRefSlot);
+
+    const block = await this.provider.getBlock('latest');
+
+    if (processingState.dataSubmitted) {
+      this.logger.debug(`using latest block ${block.number}`);
+      return block.number;
+    } else {
+      const blockNumber = await this.genesisTimeService.getBlockBySlot(currentFrameRefSlot);
+      this.logger.debug(`using processing ref slot from block ${blockNumber}`);
+      return blockNumber;
+    }
   }
 }

--- a/src/waiting-time/waiting-time.service.ts
+++ b/src/waiting-time/waiting-time.service.ts
@@ -510,7 +510,7 @@ export class WaitingTimeService {
     return Math.max(+maxExitEpoch, currentEpoch + MAX_SEED_LOOKAHEAD + 1);
   }
 
-  // returns block of processing ref lost or latest block if ref lost in future
+  // returns block of processing ref slot or latest block depending on if report submit or processing
   async getLatestOrBlockProcessingRefSlot() {
     const address = await this.lidoLocator.accountingOracle();
     const accountingOracle = OracleV2__factory.connect(address, {
@@ -527,7 +527,7 @@ export class WaitingTimeService {
       return block.number;
     } else {
       const blockNumber = await this.genesisTimeService.getBlockBySlot(currentFrameRefSlot);
-      this.logger.debug(`using processing ref slot from block ${blockNumber}`);
+      this.logger.debug(`using processing ref slot of block ${blockNumber}`);
       return blockNumber;
     }
   }


### PR DESCRIPTION
### Description

- lock on processing block of ref slot if processing started otherwise return latest block
- fixed `v1/request-time` initialization
- fixed sweep fallback provider

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
