### PR TITLE
fix: fallback for ref slot not found

### DIFF
--- a/src/waiting-time/waiting-time.service.ts
+++ b/src/waiting-time/waiting-time.service.ts
@@ -531,9 +531,14 @@ export class WaitingTimeService {
       this.logger.debug(`using latest block ${block.number}`);
       return block.number;
     } else {
-      const blockNumber = await this.genesisTimeService.getBlockBySlot(currentFrameRefSlot);
-      this.logger.debug(`using processing ref slot of block ${blockNumber}`);
-      return blockNumber;
+      try {
+        const blockNumber = await this.genesisTimeService.getBlockBySlot(currentFrameRefSlot);
+        this.logger.debug(`using processing ref slot of block ${blockNumber}`);
+        return blockNumber;
+      } catch (e) {
+        this.logger.error('error during getBlockBySlot', e);
+        return block.number;
+      }
     }
   }
 }


### PR DESCRIPTION
### Description
- fixed ref slot not found on CL provider, added fallback to latest

### Checklist:
- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
