### PR TITLE
fix: 30 min validators job update

### DIFF
--- a/src/jobs/validators/validators.service.ts
+++ b/src/jobs/validators/validators.service.ts
@@ -71,7 +71,7 @@ export class ValidatorsService {
       this.logger.error(error);
     }
 
-    const lidoWithdrawableJob = new CronJob(CronExpression.EVERY_5_MINUTES, () =>
+    const lidoWithdrawableJob = new CronJob(CronExpression.EVERY_30_MINUTES, () =>
       this.updateLidoWithdrawableValidators(),
     );
     lidoWithdrawableJob.start();


### PR DESCRIPTION
### Description
- Reduced cron job minutes, 5 min -> 30 min

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
