### PR TITLE
fix: optimized unfinalized requests fetch

### DIFF
--- a/src/jobs/queue-info/queue-info.service.spec.ts
+++ b/src/jobs/queue-info/queue-info.service.spec.ts
@@ -1,0 +1,108 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { QueueInfoService } from './queue-info.service';
+import { WithdrawalRequest } from '../../storage/queue-info/queue-info.types';
+
+function makeRequest(id: number): WithdrawalRequest {
+  return {
+    id: BigNumber.from(id),
+    amountOfStETH: BigNumber.from(id),
+    amountOfShares: BigNumber.from(id),
+    owner: '0x0000000000000000000000000000000000000001',
+    timestamp: BigNumber.from(id),
+    isFinalized: false,
+    isClaimed: false,
+    0: BigNumber.from(id),
+    1: BigNumber.from(id),
+    2: '0x0000000000000000000000000000000000000001',
+    3: BigNumber.from(id),
+    4: false,
+    5: false,
+  } as WithdrawalRequest;
+}
+
+describe('QueueInfoService', () => {
+  let service: QueueInfoService;
+  let contractWithdrawal: { getWithdrawalStatus: jest.Mock };
+  let queueInfoStorageService: { getRequests: jest.Mock };
+
+  beforeEach(() => {
+    contractWithdrawal = {
+      getWithdrawalStatus: jest.fn(async (ids: BigNumber[]) => ids.map((id) => makeRequest(id.toNumber()))),
+    };
+
+    queueInfoStorageService = {
+      getRequests: jest.fn(),
+    };
+
+    service = new QueueInfoService(
+      { log: jest.fn(), warn: jest.fn(), error: jest.fn() } as any,
+      contractWithdrawal as any,
+      {} as any,
+      {} as any,
+      queueInfoStorageService as any,
+      {} as any,
+      {} as any,
+    );
+  });
+
+  it('keeps cached active requests and fetches only new tail requests', async () => {
+    queueInfoStorageService.getRequests.mockReturnValue([makeRequest(10), makeRequest(11), makeRequest(12)]);
+
+    const lastRequestId = BigNumber.from(14);
+    const unfinalizedRequests = BigNumber.from(3);
+
+    const result = await (service as any).getUpdatedRequests(lastRequestId, unfinalizedRequests);
+
+    expect(contractWithdrawal.getWithdrawalStatus).toHaveBeenCalledTimes(1);
+    expect(contractWithdrawal.getWithdrawalStatus).toHaveBeenCalledWith([BigNumber.from(13), BigNumber.from(14)]);
+    expect(result.map((request) => request.id.toNumber())).toEqual([12, 13, 14]);
+  });
+
+  it('refetches the full active range when cached requests are not contiguous', async () => {
+    queueInfoStorageService.getRequests.mockReturnValue([makeRequest(12), makeRequest(14)]);
+
+    const lastRequestId = BigNumber.from(14);
+    const unfinalizedRequests = BigNumber.from(3);
+
+    const result = await (service as any).getUpdatedRequests(lastRequestId, unfinalizedRequests);
+
+    expect(contractWithdrawal.getWithdrawalStatus).toHaveBeenCalledTimes(1);
+    expect(contractWithdrawal.getWithdrawalStatus).toHaveBeenCalledWith([
+      BigNumber.from(12),
+      BigNumber.from(13),
+      BigNumber.from(14),
+    ]);
+    expect(result.map((request) => request.id.toNumber())).toEqual([12, 13, 14]);
+  });
+
+  it('drops finalized head requests and appends only the new tail requests', async () => {
+    queueInfoStorageService.getRequests.mockReturnValue([
+      makeRequest(0),
+      makeRequest(1),
+      makeRequest(2),
+      makeRequest(3),
+      makeRequest(4),
+      makeRequest(5),
+      makeRequest(6),
+      makeRequest(7),
+      makeRequest(8),
+      makeRequest(9),
+      makeRequest(10),
+    ]);
+
+    const lastRequestId = BigNumber.from(15);
+    const unfinalizedRequests = BigNumber.from(13);
+
+    const result = await (service as any).getUpdatedRequests(lastRequestId, unfinalizedRequests);
+
+    expect(contractWithdrawal.getWithdrawalStatus).toHaveBeenCalledTimes(1);
+    expect(contractWithdrawal.getWithdrawalStatus).toHaveBeenCalledWith([
+      BigNumber.from(11),
+      BigNumber.from(12),
+      BigNumber.from(13),
+      BigNumber.from(14),
+      BigNumber.from(15),
+    ]);
+    expect(result.map((request) => request.id.toNumber())).toEqual([3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+  });
+});

--- a/src/jobs/queue-info/queue-info.service.spec.ts
+++ b/src/jobs/queue-info/queue-info.service.spec.ts
@@ -2,6 +2,8 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { QueueInfoService } from './queue-info.service';
 import { WithdrawalRequest } from '../../storage/queue-info/queue-info.types';
 
+jest.mock('common/config', () => ({}));
+
 function makeRequest(id: number): WithdrawalRequest {
   return {
     id: BigNumber.from(id),

--- a/src/jobs/queue-info/queue-info.service.ts
+++ b/src/jobs/queue-info/queue-info.service.ts
@@ -7,10 +7,12 @@ import { OneAtTime } from '@lido-nestjs/decorators';
 import { QueueInfoStorageService } from 'storage';
 import { WithdrawalQueue, Lido, WITHDRAWAL_QUEUE_CONTRACT_TOKEN, LIDO_CONTRACT_TOKEN } from '@lido-nestjs/contracts';
 import { SimpleFallbackJsonRpcBatchProvider } from '@lido-nestjs/execution';
+import { BigNumber } from '@ethersproject/bignumber';
 import { WithdrawalRequest } from 'storage/queue-info/queue-info.types';
 
 @Injectable()
 export class QueueInfoService {
+  protected static readonly WITHDRAWAL_STATUS_PAGE_SIZE = 50;
   private job: CronJob;
   static SERVICE_LOG_NAME = 'queue info';
 
@@ -73,12 +75,7 @@ export class QueueInfoService {
           this.contractWithdrawal.getLastRequestId(),
         ]);
 
-        const requestIds = new Array(unfinalizedRequests.toNumber())
-          .fill(true)
-          .map((_, i) => lastRequestId.sub(i))
-          .reverse();
-        const withdrawalStatuses = await this.contractWithdrawal.getWithdrawalStatus(requestIds);
-        const requests = withdrawalStatuses.map((w, i) => ({ ...w, id: requestIds[i] } as WithdrawalRequest));
+        const requests = await this.getUpdatedRequests(lastRequestId, unfinalizedRequests);
 
         this.queueInfoStorageService.setRequests(requests);
         this.queueInfoStorageService.setStETH(unfinalizedStETH);
@@ -101,6 +98,77 @@ export class QueueInfoService {
         });
       },
     );
+  }
+
+  protected async getUpdatedRequests(
+    lastRequestId: BigNumber,
+    unfinalizedRequests: BigNumber,
+  ): Promise<WithdrawalRequest[]> {
+    const requestIds = this.getRequestIds(lastRequestId, unfinalizedRequests);
+    if (requestIds.length === 0) {
+      return [];
+    }
+
+    const cachedRequests = this.queueInfoStorageService.getRequests();
+    const firstExpectedRequestId = requestIds[0];
+    const cachedActiveRequests = cachedRequests.filter(
+      (request) => request.id.gte(firstExpectedRequestId) && request.id.lte(lastRequestId),
+    );
+
+    if (!this.hasContiguousIds(cachedActiveRequests, firstExpectedRequestId)) {
+      this.logger.warn('Queue cache is inconsistent, refetching all unfinalized requests', {
+        service: QueueInfoService.SERVICE_LOG_NAME,
+        cachedRequests: cachedRequests.length,
+        cachedActiveRequests: cachedActiveRequests.length,
+        unfinalizedRequests: unfinalizedRequests.toString(),
+      });
+      return await this.fetchRequestsByIds(requestIds);
+    }
+
+    const lastCachedRequestId = cachedActiveRequests[cachedActiveRequests.length - 1]?.id;
+    const nextRequestId = lastCachedRequestId ? lastCachedRequestId.add(1) : firstExpectedRequestId;
+    const nextRequestIndex = nextRequestId.sub(firstExpectedRequestId).toNumber();
+    const newRequestIds = requestIds.slice(nextRequestIndex);
+
+    if (newRequestIds.length === 0) {
+      return cachedActiveRequests;
+    }
+
+    const newRequests = await this.fetchRequestsByIds(newRequestIds);
+    return cachedActiveRequests.concat(newRequests);
+  }
+
+  protected getRequestIds(lastRequestId: BigNumber, unfinalizedRequests: BigNumber): BigNumber[] {
+    if (unfinalizedRequests.eq(0)) {
+      return [];
+    }
+
+    const firstRequestId = lastRequestId.sub(unfinalizedRequests).add(1);
+    return new Array(unfinalizedRequests.toNumber()).fill(true).map((_, i) => firstRequestId.add(i));
+  }
+
+  protected hasContiguousIds(requests: WithdrawalRequest[], firstExpectedRequestId: BigNumber): boolean {
+    for (let i = 0; i < requests.length; i++) {
+      if (!requests[i].id.eq(firstExpectedRequestId.add(i))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  protected async fetchRequestsByIds(requestIds: BigNumber[]): Promise<WithdrawalRequest[]> {
+    const requests: WithdrawalRequest[] = [];
+
+    for (let i = 0; i < requestIds.length; i += QueueInfoService.WITHDRAWAL_STATUS_PAGE_SIZE) {
+      const requestIdsPage = requestIds.slice(i, i + QueueInfoService.WITHDRAWAL_STATUS_PAGE_SIZE);
+      const withdrawalStatuses = await this.contractWithdrawal.getWithdrawalStatus(requestIdsPage);
+      requests.push(
+        ...withdrawalStatuses.map((w, index) => ({ ...w, id: requestIdsPage[index] } as WithdrawalRequest)),
+      );
+    }
+
+    return requests;
   }
 
   protected getNextUpdateDate() {


### PR DESCRIPTION
### Description

- fixed high CU EL usage for unfinalized requests
- fetch by pages and only delta requests

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
