### PR TITLE
fix: take minimum CL/EL rewards per frame, not maximum

### DIFF
--- a/src/events/rewards/rewards.service.spec.ts
+++ b/src/events/rewards/rewards.service.spec.ts
@@ -1,0 +1,81 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { RewardsService } from './rewards.service';
+
+jest.mock('common/config', () => ({}));
+
+describe('RewardsService.getMinLastTotalRewardsPerFrame', () => {
+  let service: RewardsService;
+
+  beforeEach(() => {
+    service = new RewardsService(
+      { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+  });
+
+  it('returns the minimum of CL and EL rewards across the last week (pessimistic projection)', async () => {
+    // Three reports across the week: CL drops, spikes, drops again; EL drops, spikes, drops again.
+    // The pessimistic (= safer for users, longer estimate) choice is the minimum of each axis,
+    // which can land on different reports for CL vs EL.
+    const reports = [
+      { blockNumber: 1, frames: BigNumber.from(1) },
+      { blockNumber: 2, frames: BigNumber.from(1) },
+      { blockNumber: 3, frames: BigNumber.from(1) },
+    ];
+    const perBlockRewards: Record<number, { clRewards: BigNumber; elRewards: BigNumber }> = {
+      1: { clRewards: BigNumber.from(5), elRewards: BigNumber.from(50) },
+      2: { clRewards: BigNumber.from(100), elRewards: BigNumber.from(100) },
+      3: { clRewards: BigNumber.from(3), elRewards: BigNumber.from(30) },
+    };
+
+    jest.spyOn(service as any, 'getFramesFromLastReports').mockResolvedValue(reports);
+    jest
+      .spyOn(service as any, 'getRewardsByBlockNumber')
+      .mockImplementation(async (blockNumber: number) => perBlockRewards[blockNumber]);
+
+    const result = await service.getMinLastTotalRewardsPerFrame();
+
+    expect(result).not.toBeNull();
+    expect(result.clRewards.toString()).toBe('3');
+    expect(result.elRewards.toString()).toBe('30');
+    expect(result.allRewards.toString()).toBe('33');
+  });
+
+  it('returns the minimum even when a single report dominates both axes', async () => {
+    const reports = [
+      { blockNumber: 1, frames: BigNumber.from(1) },
+      { blockNumber: 2, frames: BigNumber.from(1) },
+    ];
+    const perBlockRewards: Record<number, { clRewards: BigNumber; elRewards: BigNumber }> = {
+      1: { clRewards: BigNumber.from(10), elRewards: BigNumber.from(20) },
+      2: { clRewards: BigNumber.from(1000), elRewards: BigNumber.from(2000) },
+    };
+
+    jest.spyOn(service as any, 'getFramesFromLastReports').mockResolvedValue(reports);
+    jest
+      .spyOn(service as any, 'getRewardsByBlockNumber')
+      .mockImplementation(async (blockNumber: number) => perBlockRewards[blockNumber]);
+
+    const result = await service.getMinLastTotalRewardsPerFrame();
+
+    expect(result.clRewards.toString()).toBe('10');
+    expect(result.elRewards.toString()).toBe('20');
+    expect(result.allRewards.toString()).toBe('30');
+  });
+
+  it('returns zeros when no TokenRebased reports are found', async () => {
+    jest.spyOn(service as any, 'getFramesFromLastReports').mockResolvedValue(null);
+
+    const result = await service.getMinLastTotalRewardsPerFrame();
+
+    expect(result.clRewards.toString()).toBe('0');
+    expect(result.elRewards.toString()).toBe('0');
+    expect(result.allRewards.toString()).toBe('0');
+  });
+});

--- a/src/events/rewards/rewards.service.ts
+++ b/src/events/rewards/rewards.service.ts
@@ -110,11 +110,11 @@ export class RewardsService {
 
     // find minimum for last week
     rewards.forEach((r) => {
-      if (minCL.lt(r.clRewards)) {
+      if (minCL.gt(r.clRewards)) {
         minCL = r.clRewards;
       }
 
-      if (minEL.lt(r.elRewards)) {
+      if (minEL.gt(r.elRewards)) {
         minEL = r.elRewards;
       }
     });


### PR DESCRIPTION


### Description

## Summary

- Fix `getMinLastTotalRewardsPerFrame` to actually return the minimum (it was returning max).
- Add unit tests for the loop direction and the empty-reports fallback.

## Why

The inner loop at `rewards.service.ts:108-120` was introduced in 8b52137 ("added min rewards for week") with the intent to take the **minimum** CL/EL rewards across the last week's `TokenRebased` events — pessimistic projection, longer estimate, safer for users. The variable names (`minCL`/`minEL`) and the comment (`// find minimum for last week`) state this directly.

The implementation used `lt`:

```ts
if (minCL.lt(r.clRewards)) { minCL = r.clRewards; }
```

…which replaces `minCL` whenever it is *smaller* than the next sample — i.e. moves toward the **maximum**. Final value was max, not min.

## Production impact

`rewardsPerFrame` is consumed in 4 places in `WaitingTimeService`:

| Consumer | Effect of larger `rewardsPerFrame` |
|---|---|
| `calculateFrameByRewardsOnly` | shorter wait |
| `calculateFrameByValidatorBalances` (utils) | shorter wait |
| `calculateFrameExitValidatorsCaseWithVEBO` | shorter wait |
| `getVaultsBalance` haircut (one-shot) | longer wait |

Three of four push toward shorter (optimistic). Net effect of the bug: production estimates were 1+ frame shorter than designed.

**After this fix, `/v1/request-time` and `/v2/request-time` will return slightly longer estimates** — matching the original design. No API contract change, but consumers (staking-widget, Lido SDK) will see numerically different responses for the same inputs once deployed.

## Test plan

- [x] `yarn test --testPathPattern=rewards.service` — 3/3 pass
- [x] `yarn test` full suite — 24/24 pass (the 2 suite-level TS errors on `CHAINS.Hoodi` are pre-existing on `develop`, unrelated to this PR)
- [x] `yarn eslint` on touched files — clean
- [x] `yarn prettier --check` on touched files — clean

### Demo

<!--- If thee are visual changes, attach a link to a specific section on preview stand / add screenshots / record a [loom](https://www.loom.com/). -->

### Code review notes

<!--- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!--- List all possible edge cases and how to test them. -->

### Checklist:

- [ ] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
