### PR TITLE
feat: added churnlimit to cache, returned mainnet default job, added …

### DIFF
--- a/src/jobs/contract-config/contract-config.module.ts
+++ b/src/jobs/contract-config/contract-config.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { JobModule } from 'common/job';
 import { ContractConfigService } from './contract-config.service';
 import { ContractConfigStorageModule } from 'storage';
+import { ValidatorsModule } from '../validators';
 
 @Module({
-  imports: [JobModule, ContractConfigStorageModule],
+  imports: [JobModule, ContractConfigStorageModule, ValidatorsModule],
   providers: [ContractConfigService],
   exports: [ContractConfigService],
 })

--- a/src/jobs/contract-config/contract-config.service.ts
+++ b/src/jobs/contract-config/contract-config.service.ts
@@ -14,6 +14,7 @@ import {
   LidoLocator,
 } from '@lido-nestjs/contracts';
 import { ContractConfigStorageService } from 'storage';
+import { ValidatorsService } from '../validators';
 
 @Injectable()
 export class ContractConfigService {
@@ -27,6 +28,7 @@ export class ContractConfigService {
     @Inject(VALIDATORS_EXIT_BUS_ORACLE_HASH_CONSENSUS_TOKEN) protected readonly veboHashConsensus: HashConsensus,
     @Inject(LIDO_LOCATOR_CONTRACT_TOKEN) protected readonly lidoLocator: LidoLocator,
 
+    protected readonly validatorsService: ValidatorsService,
     protected readonly contractConfig: ContractConfigStorageService,
     protected readonly configService: ConfigService,
     protected readonly jobService: JobService,
@@ -122,6 +124,11 @@ export class ContractConfigService {
         this.contractConfig.setWithdrawalVaultAddress(withdrawalVaultAddress);
         this.contractConfig.setElRewardsVaultAddress(elRewardsVaultAddress);
         this.contractConfig.setLastUpdate(Math.floor(Date.now() / 1000));
+
+        this.validatorsService.rescheduleCronJobs(
+          veboFrameConfig.initialEpoch.toNumber(),
+          veboFrameConfig.epochsPerFrame.toNumber(),
+        );
 
         this.logger.log('End update contract config', {
           service: ContractConfigService.SERVICE_LOG_NAME,

--- a/src/jobs/validators/validators.constants.ts
+++ b/src/jobs/validators/validators.constants.ts
@@ -3,8 +3,7 @@ import { CHAINS } from '@lido-nestjs/constants';
 export const MAX_SEED_LOOKAHEAD = 4;
 
 export const ORACLE_REPORTS_CRON_BY_CHAIN_ID = {
-  // 45-epoch VEBO frame anchored at 12:00 UTC, refreshed +30m after each report.
-  [CHAINS.Mainnet]: ['54 2 * * *', '42 7 * * *', '30 12 * * *', '18 17 * * *', '6 22 * * *'],
+  [CHAINS.Mainnet]: '30 4/8 * * *', // 4 utc, 12 utc, 20 utc
   [CHAINS.Hoodi]: ['54 2 * * *', '42 7 * * *', '30 12 * * *', '18 17 * * *', '6 22 * * *'],
 };
 

--- a/src/jobs/validators/validators.service.ts
+++ b/src/jobs/validators/validators.service.ts
@@ -20,6 +20,7 @@ import { CronExpression } from '@nestjs/schedule';
 import { PrometheusService } from 'common/prometheus';
 import { stringifyFrameBalances } from 'common/validators/strigify-frame-balances';
 import { getValidatorWithdrawalTimestamp } from './utils/get-validator-withdrawal-timestamp';
+import { hasCompoundingWithdrawalCredential, hasEth1WithdrawalCredential } from './utils/validator-state-utils';
 import { IndexedValidator, ResponseValidatorsData } from '../../common/consensus-provider/consensus-provider.types';
 import { SweepService, WithdrawalSweepState } from '../../common/sweep';
 import { toEth } from '../../common/utils/to-eth';
@@ -92,7 +93,7 @@ export class ValidatorsService {
   public rescheduleCronJobs(newInitialEpoch: number, newEpochsPerFrame: number) {
     const cronTimes = this.buildCron(newInitialEpoch, newEpochsPerFrame);
 
-    if (this.validatorUpdateCronTimes.length === 0) {
+    if (cronTimes.length === 0) {
       this.logger.log('Skip validators cron reschedule because  nothing to schedule', {
         service: ValidatorsService.SERVICE_LOG_NAME,
         cronTimes,
@@ -202,6 +203,26 @@ export class ValidatorsService {
     this.logger.debug('lidoValidators', {
       lidoValidatorsLength: lidoValidators.length,
       service: ValidatorsService.SERVICE_LOG_NAME,
+    });
+    const lidoValidatorsWithdrawalCredentialsStats = lidoValidators.reduce(
+      (stats, validator) => {
+        if (hasEth1WithdrawalCredential(validator.validator)) {
+          stats.eth1Address++;
+        }
+
+        if (hasCompoundingWithdrawalCredential(validator.validator)) {
+          stats.compounding++;
+        }
+
+        return stats;
+      },
+      { eth1Address: 0, compounding: 0 },
+    );
+    this.logger.log('Lido validators withdrawal credentials stats', {
+      service: ValidatorsService.SERVICE_LOG_NAME,
+      lidoValidatorsLength: lidoValidators.length,
+      eth1AddressWithdrawalCredentialsCount: lidoValidatorsWithdrawalCredentialsStats.eth1Address,
+      compoundingWithdrawalCredentialsCount: lidoValidatorsWithdrawalCredentialsStats.compounding,
     });
     const frameBalances = {};
     const currentEpoch = this.genesisTimeService.getCurrentEpoch();

--- a/src/jobs/validators/validators.service.ts
+++ b/src/jobs/validators/validators.service.ts
@@ -204,26 +204,7 @@ export class ValidatorsService {
       lidoValidatorsLength: lidoValidators.length,
       service: ValidatorsService.SERVICE_LOG_NAME,
     });
-    const lidoValidatorsWithdrawalCredentialsStats = lidoValidators.reduce(
-      (stats, validator) => {
-        if (hasEth1WithdrawalCredential(validator.validator)) {
-          stats.eth1Address++;
-        }
 
-        if (hasCompoundingWithdrawalCredential(validator.validator)) {
-          stats.compounding++;
-        }
-
-        return stats;
-      },
-      { eth1Address: 0, compounding: 0 },
-    );
-    this.logger.log('Lido validators withdrawal credentials stats', {
-      service: ValidatorsService.SERVICE_LOG_NAME,
-      lidoValidatorsLength: lidoValidators.length,
-      eth1AddressWithdrawalCredentialsCount: lidoValidatorsWithdrawalCredentialsStats.eth1Address,
-      compoundingWithdrawalCredentialsCount: lidoValidatorsWithdrawalCredentialsStats.compounding,
-    });
     const frameBalances = {};
     const currentEpoch = this.genesisTimeService.getCurrentEpoch();
     const totalValidatorsCount = this.validatorsStorageService.getTotalValidatorsCount();

--- a/src/jobs/validators/validators.service.ts
+++ b/src/jobs/validators/validators.service.ts
@@ -6,7 +6,7 @@ import { ConfigService } from 'common/config';
 import { FAR_FUTURE_EPOCH } from 'common/constants';
 import { ConsensusProviderService } from 'common/consensus-provider';
 import { ConsensusClientService } from 'common/consensus-provider/consensus-client.service';
-import { GenesisTimeService } from 'common/genesis-time';
+import { GenesisTimeService, SECONDS_PER_SLOT, SLOTS_PER_EPOCH } from 'common/genesis-time';
 import { OneAtTime } from '@lido-nestjs/decorators';
 import { ValidatorsStorageService } from 'storage';
 import { ORACLE_REPORTS_CRON_BY_CHAIN_ID, MAX_SEED_LOOKAHEAD } from './validators.constants';
@@ -27,6 +27,9 @@ import { getChurnLimit } from './utils/get-churn-limit';
 
 export class ValidatorsService {
   static SERVICE_LOG_NAME = 'validators';
+  private cronJobs: CronJob[] = [];
+  private validatorUpdateCronTimes: string[] = [];
+  protected static readonly UPDATE_DELAY_MS = 30 * 60 * 1000;
 
   constructor(
     @Inject(LOGGER_PROVIDER) protected readonly logger: LoggerService,
@@ -57,15 +60,19 @@ export class ValidatorsService {
     const chainId = this.configService.get('CHAIN_ID');
     const cronByChainId = ORACLE_REPORTS_CRON_BY_CHAIN_ID[chainId] ?? CronExpression.EVERY_3_HOURS;
     const cronTimes = envCronTime ? [envCronTime] : Array.isArray(cronByChainId) ? cronByChainId : [cronByChainId];
+    this.validatorUpdateCronTimes = cronTimes;
 
     try {
       await this.updateValidators();
     } catch (error) {
       this.logger.error(error);
     }
-    cronTimes.forEach((cronTime) => {
-      const mainJob = new CronJob(cronTime, () => this.updateValidators());
-      mainJob.start();
+
+    this.cronJobs = cronTimes.map((cronTime) => {
+      const cronJob = new CronJob(cronTime, () => this.updateValidators());
+      cronJob.start();
+
+      return cronJob;
     });
 
     try {
@@ -80,6 +87,41 @@ export class ValidatorsService {
     lidoWithdrawableJob.start();
 
     this.logger.log('Service initialized', { service: ValidatorsService.SERVICE_LOG_NAME, cronTime: cronTimes });
+  }
+
+  public rescheduleCronJobs(newInitialEpoch: number, newEpochsPerFrame: number) {
+    const cronTimes = this.buildCron(newInitialEpoch, newEpochsPerFrame);
+
+    if (this.validatorUpdateCronTimes.length === 0) {
+      this.logger.log('Skip validators cron reschedule because  nothing to schedule', {
+        service: ValidatorsService.SERVICE_LOG_NAME,
+        cronTimes,
+      });
+      return;
+    }
+
+    if (
+      this.validatorUpdateCronTimes.length === cronTimes.length &&
+      this.validatorUpdateCronTimes.every((cronTime, index) => cronTime === cronTimes[index])
+    ) {
+      this.logger.log('Skip validators cron reschedule because cron times did not change', {
+        service: ValidatorsService.SERVICE_LOG_NAME,
+        cronTimes,
+      });
+      return;
+    }
+
+    this.cronJobs.forEach((cronJob) => {
+      cronJob.stop();
+    });
+
+    this.validatorUpdateCronTimes = cronTimes;
+    this.cronJobs = cronTimes.map((cronTime) => {
+      const cronJob = new CronJob(cronTime, () => this.updateValidators());
+      cronJob.start();
+
+      return cronJob;
+    });
   }
 
   @OneAtTime()
@@ -308,5 +350,41 @@ export class ValidatorsService {
     }, BigNumber.from(0));
 
     this.prometheusService.sumValidatorsBalances.set(toEth(sum).toNumber());
+  }
+
+  // example: newInitialEpoch=91799, newEpochsPerFrame=45
+  // 45 * 32 * 12 / 3600 = 4.8 hours each frame (5 times per day)
+  public buildCron(newInitialEpoch: number, newEpochsPerFrame: number) {
+    const firstDate = this.genesisTimeService.getTimestampByEpoch(newInitialEpoch);
+    const eachSec = newEpochsPerFrame * SLOTS_PER_EPOCH * SECONDS_PER_SLOT;
+    const secondsPerDay = 24 * 60 * 60;
+
+    if (secondsPerDay % eachSec !== 0) {
+      this.logger.warn('VEBO frame duration does not fit a simple daily cron schedule', {
+        service: ValidatorsService.SERVICE_LOG_NAME,
+        newInitialEpoch,
+        newEpochsPerFrame,
+        eachSec,
+      });
+      return [];
+    }
+
+    const firstRunAt = new Date(firstDate + ValidatorsService.UPDATE_DELAY_MS);
+    const firstRunAtSecondOfDay =
+      firstRunAt.getUTCHours() * 3600 + firstRunAt.getUTCMinutes() * 60 + firstRunAt.getUTCSeconds();
+    const runsPerDay = secondsPerDay / eachSec;
+
+    const cronEntries = Array.from({ length: runsPerDay }, (_, index) => {
+      const runAtSecondOfDay = (firstRunAtSecondOfDay + index * eachSec) % secondsPerDay;
+      const hours = Math.floor(runAtSecondOfDay / 3600);
+      const minutes = Math.floor((runAtSecondOfDay % 3600) / 60);
+
+      return {
+        sortKey: runAtSecondOfDay,
+        cron: `${minutes} ${hours} * * *`,
+      };
+    });
+
+    return cronEntries.sort((left, right) => left.sortKey - right.sortKey).map((entry) => entry.cron);
   }
 }

--- a/src/storage/validators/validators-cache.service.ts
+++ b/src/storage/validators/validators-cache.service.ts
@@ -11,7 +11,7 @@ export class ValidatorsCacheService {
   static CACHE_FILE_NAME = 'validators-state.txt';
   static CACHE_DIR = 'cache';
   static CACHE_DATA_DIVIDER = '|';
-  static CACHE_DATA_LENGTH = 5;
+  static CACHE_DATA_LENGTH = 6;
   static SERVICE_LOG_NAME = 'validators cache';
   static CACHE_INVALIDATE_TIME = 3 * 3600; // 3 hours
 
@@ -56,6 +56,7 @@ export class ValidatorsCacheService {
       this.validatorsStorage.setLastUpdate(Number(data[2]));
       this.validatorsStorage.setFrameBalances(this.parseFrameBalances(data[3]));
       this.validatorsStorage.setSweepMeanEpochs(Number(data[4]));
+      this.validatorsStorage.setChurnLimit(Number(data[5]));
 
       this.logger.log(`success initialize from cache file ${cacheFileName}`, {
         service: ValidatorsCacheService.SERVICE_LOG_NAME,
@@ -80,6 +81,7 @@ export class ValidatorsCacheService {
       this.validatorsStorage.getLastUpdate(),
       stringifyFrameBalances(this.validatorsStorage.getFrameBalances()),
       this.validatorsStorage.getSweepMeanEpochs(),
+      this.validatorsStorage.getChurnLimit(),
     ].join(ValidatorsCacheService.CACHE_DATA_DIVIDER);
     await writeFile(cacheFileName, data);
     this.logger.log(`success save to file ${cacheFileName}`, { service: ValidatorsCacheService.SERVICE_LOG_NAME });

--- a/src/waiting-time/waiting-time.service.ts
+++ b/src/waiting-time/waiting-time.service.ts
@@ -354,10 +354,12 @@ export class WaitingTimeService {
   public checkIsInitializing() {
     const requests = this.queueInfo.getRequests();
     const validatorsLastUpdate = this.validators.getLastUpdate();
+    const validatorsChurnLimit = this.validators.getChurnLimit();
     const queueInfoLastUpdate = this.queueInfo.getLastUpdate();
     const contractConfigLastUpdate = this.contractConfig.getLastUpdate();
 
-    const isInitialized = validatorsLastUpdate && queueInfoLastUpdate && requests && contractConfigLastUpdate;
+    const isInitialized =
+      validatorsLastUpdate && validatorsChurnLimit && queueInfoLastUpdate && requests && contractConfigLastUpdate;
 
     if (!isInitialized) {
       return {


### PR DESCRIPTION
### Description

- schedule `validators update` job by VEBO config
- fix 500 before initilization, added churn limit to cache and init check


### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
