### PR TITLE
Feature/si 2572 sr 3 wq api updates

### DIFF
--- a/how-estimation-works.md
+++ b/how-estimation-works.md
@@ -112,6 +112,14 @@ It's needed to select the Lido-participating validators which are already in pro
 - `rewardsPerEpoch` is calculated as described in the provided [prediction model](https://hackmd.io/@lido/r1fau3aJ3?type=view#Predict-available-ETH-before-next-withdrawn).
 - Exited validators become withdrawable only after the withdrawal [sweep](#sweeping-mean) approaches them.
 
+### Rewards available for withdrawals
+
+Post-SR-3, governance sets a `depositsReserveTarget` that the Lido contract refills the deposits reserve to at every oracle report. The per-frame rewards rate used in projection formulas (cases 3.i, 3.ii, 3.iii) is therefore net of this claim:
+
+`rewardsAvailableForWithdrawals = rewardsPerFrame - min(target, rewardsPerFrame)`
+
+Conservative — assumes worst case where the reserve fully drains between reports. When `target = 0` (governance hasn't set one), this is a no-op. Source: `Lido.getDepositsReserveTarget()`.
+
 ### Churn limit
 
 Post-Electra exit churn is balance-based: protocol caps it at `[128, 256]` ETH/epoch with the dynamic value being `totalActiveBalance / 2^16` (gwei). wq-api computes this in the validators job from `totalActiveBalance` and exposes it as a 32-ETH-equivalent count for downstream formulas; multiplying back by `MIN_ACTIVATION_BALANCE` is a unit identity that yields ETH/epoch.

--- a/src/common/contracts/abi/lido-extension.abi.ts
+++ b/src/common/contracts/abi/lido-extension.abi.ts
@@ -17,4 +17,11 @@ export const LIDO_EXTENSION_ABI = [
     inputs: [],
     outputs: [{ name: 'depositsReserve', type: 'uint256' }],
   },
+  {
+    name: 'getDepositsReserveTarget',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: 'depositsReserveTarget', type: 'uint256' }],
+  },
 ] as const;

--- a/src/jobs/contract-config/contract-config.service.ts
+++ b/src/jobs/contract-config/contract-config.service.ts
@@ -1,4 +1,5 @@
 import { CronJob } from 'cron';
+import { BigNumber } from '@ethersproject/bignumber';
 import { Inject, Injectable } from '@nestjs/common';
 import { LOGGER_PROVIDER, LoggerService } from 'common/logger';
 import { JobService } from 'common/job';
@@ -11,6 +12,7 @@ import {
   LIDO_LOCATOR_CONTRACT_TOKEN,
   LidoLocator,
 } from '@lido-nestjs/contracts';
+import { SimpleFallbackJsonRpcBatchProvider } from '@lido-nestjs/execution';
 import { ContractConfigStorageService } from 'storage';
 import { ValidatorsService } from '../validators';
 import { LidoExtensionReader } from './lido-extension-reader';
@@ -29,6 +31,7 @@ export class ContractConfigService {
 
     protected readonly oracleLimitsReader: OracleLimitsReader,
     protected readonly lidoExtensionReader: LidoExtensionReader,
+    protected readonly provider: SimpleFallbackJsonRpcBatchProvider,
     protected readonly validatorsService: ValidatorsService,
     protected readonly contractConfig: ContractConfigStorageService,
     protected readonly configService: ConfigService,
@@ -100,9 +103,18 @@ export class ContractConfigService {
       async () => {
         this.logger.log('Start update contract config', { service: ContractConfigService.SERVICE_LOG_NAME });
 
+        // Gate the target read on the previous-tick storage flag: don't call on pre-SR-3
+        // contracts (would emit warn-spam from the defensive try/catch in the reader). One-tick
+        // lag after SR-3 detection is acceptable — target stays at default 0 for that tick,
+        // projection netting becomes a no-op (same behavior as pre-SR-3). Next tick fetches
+        // the real value.
+        const wasSrv3KnownLastTick = this.contractConfig.getLidoSupportsDepositsReserve();
+        const blockNumber = await this.provider.getBlockNumber();
+
         const [
           unifiedLimits,
           lidoSupportsDepositsReserve,
+          depositsReserveTarget,
           frameConfig,
           veboFrameConfig,
           accountingOracleAddress,
@@ -111,6 +123,9 @@ export class ContractConfigService {
         ] = await Promise.all([
           this.oracleLimitsReader.read(),
           this.lidoExtensionReader.probe(),
+          wasSrv3KnownLastTick
+            ? this.lidoExtensionReader.getDepositsReserveTargetAt(blockNumber)
+            : Promise.resolve(BigNumber.from(0)),
           this.accountingOracleHashConsensus.getFrameConfig(),
           this.veboHashConsensus.getFrameConfig(),
           this.lidoLocator.accountingOracle(),
@@ -123,6 +138,7 @@ export class ContractConfigService {
           unifiedLimits.maxBalanceExitRequestedPerReportInEth,
         );
         this.contractConfig.setLidoSupportsDepositsReserve(lidoSupportsDepositsReserve);
+        this.contractConfig.setDepositsReserveTarget(depositsReserveTarget);
         this.contractConfig.setInitialEpoch(frameConfig.initialEpoch.toNumber());
         this.contractConfig.setEpochsPerFrameVEBO(veboFrameConfig.epochsPerFrame.toNumber());
         this.contractConfig.setEpochsPerFrame(frameConfig.epochsPerFrame.toNumber());
@@ -141,6 +157,7 @@ export class ContractConfigService {
           requestTimestampMargin: unifiedLimits.requestTimestampMargin.toNumber(),
           maxBalanceExitRequestedPerReportInEth: unifiedLimits.maxBalanceExitRequestedPerReportInEth.toNumber(),
           lidoSupportsDepositsReserve,
+          depositsReserveTarget: depositsReserveTarget.toString(),
           initialEpoch: frameConfig.initialEpoch.toNumber(),
           epochsPerFrameVEBO: veboFrameConfig.epochsPerFrame.toNumber(),
           epochsPerFrame: frameConfig.epochsPerFrame.toNumber(),

--- a/src/jobs/contract-config/lido-extension-reader.spec.ts
+++ b/src/jobs/contract-config/lido-extension-reader.spec.ts
@@ -125,4 +125,43 @@ describe('LidoExtensionReader', () => {
       expect(secondCallArgs[1]).toBe(200);
     });
   });
+
+  describe('getDepositsReserveTargetAt', () => {
+    it('returns decoded uint256 at the given block', async () => {
+      // 5,000 ETH governance-set target = 5,000 × 10^18 wei
+      const targetWei = BigInt('5000000000000000000000');
+      provider.call.mockResolvedValue(encodeUint256(targetWei));
+
+      const result = await reader.getDepositsReserveTargetAt(12_345_678);
+
+      expect(result.toString()).toBe(targetWei.toString());
+      expect(provider.call).toHaveBeenCalledWith({ to: LIDO_ADDR, data: expect.any(String) }, 12_345_678);
+    });
+
+    it('returns 0 and logs warn on revert (e.g. pre-SR-3 contract)', async () => {
+      provider.call.mockRejectedValue(new Error('execution reverted'));
+
+      const result = await reader.getDepositsReserveTargetAt(12_345_678);
+
+      expect(result.toNumber()).toBe(0);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'getDepositsReserveTargetAt failed; falling back to 0 target',
+        expect.objectContaining({
+          lidoAddress: LIDO_ADDR,
+          blockTag: 12_345_678,
+          error: 'execution reverted',
+        }),
+      );
+    });
+
+    it('uses a different selector than getDepositsReserveAt (sibling method, not alias)', async () => {
+      provider.call.mockResolvedValue(encodeUint256(0));
+      await reader.getDepositsReserveAt(100);
+      await reader.getDepositsReserveTargetAt(100);
+
+      const reserveSelector = provider.call.mock.calls[0][0].data;
+      const targetSelector = provider.call.mock.calls[1][0].data;
+      expect(reserveSelector).not.toBe(targetSelector);
+    });
+  });
 });

--- a/src/jobs/contract-config/lido-extension-reader.ts
+++ b/src/jobs/contract-config/lido-extension-reader.ts
@@ -96,10 +96,7 @@ export class LidoExtensionReader {
   public async getDepositsReserveTargetAt(blockTag: number): Promise<BigNumber> {
     const lidoAddress = this.contractLido.address;
     try {
-      const data = await this.provider.call(
-        { to: lidoAddress, data: GET_DEPOSITS_RESERVE_TARGET_SELECTOR },
-        blockTag,
-      );
+      const data = await this.provider.call({ to: lidoAddress, data: GET_DEPOSITS_RESERVE_TARGET_SELECTOR }, blockTag);
       const [target] = LIDO_EXTENSION_INTERFACE.decodeFunctionResult('getDepositsReserveTarget', data);
       return BigNumber.from(target.toString());
     } catch (error: unknown) {

--- a/src/jobs/contract-config/lido-extension-reader.ts
+++ b/src/jobs/contract-config/lido-extension-reader.ts
@@ -7,21 +7,24 @@ import { LOGGER_PROVIDER, LoggerService } from 'common/logger';
 import { LIDO_EXTENSION_ABI } from 'common/contracts/abi/lido-extension.abi';
 
 const GET_DEPOSITS_RESERVE_SELECTOR = id('getDepositsReserve()').slice(0, 10);
+const GET_DEPOSITS_RESERVE_TARGET_SELECTOR = id('getDepositsReserveTarget()').slice(0, 10);
 const LIDO_EXTENSION_INTERFACE = new Interface(LIDO_EXTENSION_ABI);
 
 /**
  * Probes the Lido proxy for SR-3 extension methods (specifically `getDepositsReserve()`)
- * and reads the deposits-reserve value at a given block. Lido is behind a stable proxy,
- * so address-as-trigger discrimination doesn't apply — we use method-existence probing.
+ * and reads buffer-reserve values at a given block. Lido is behind a stable proxy, so
+ * address-as-trigger discrimination doesn't apply — we use method-existence probing.
  *
  * Once `getDepositsReserve()` is observed responding (post-SR-3), the in-memory latch flips
  * to `true` and never reverts. Defends against transient RPC failures masquerading as a
  * "pre-SR-3" signal — a protocol cannot un-deploy SR-3, so a one-way latch is correct.
  *
- * Two methods, used by different consumers:
+ * Methods, used by different consumers:
  * - `probe()` — called by contract-config job once per tick to update the storage boolean.
- * - `getDepositsReserveAt(blockTag)` — called by BlockStateCacheService for the actual value
- *   at the same block where buffer was read.
+ * - `getDepositsReserveAt(blockTag)` — called by BlockStateCacheService for the current
+ *   reserve value at the same block where buffer was read.
+ * - `getDepositsReserveTargetAt(blockTag)` — called by the contract-config job for the
+ *   governance-set target. Used by the rewards-projection netting in WaitingTimeService.
  */
 @Injectable()
 export class LidoExtensionReader {
@@ -72,6 +75,35 @@ export class LidoExtensionReader {
       return BigNumber.from(reserve.toString());
     } catch (error: unknown) {
       this.logger.warn('getDepositsReserveAt failed; falling back to 0 reserve', {
+        service: LidoExtensionReader.SERVICE_LOG_NAME,
+        lidoAddress,
+        blockTag,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return BigNumber.from(0);
+    }
+  }
+
+  /**
+   * Reads `getDepositsReserveTarget()` at the given block — the governance-set target the
+   * protocol refills `depositsReserve` to at every oracle report. Used by rewards-projection
+   * formulas to net out the per-frame refill claim from rewards-available-for-withdrawals.
+   *
+   * Defensive: on revert or RPC error returns `0` and logs at `warn`. Caller is expected to
+   * gate on the cached `lidoSupportsDepositsReserve` flag, but a 0 fallback is safe — the
+   * netting becomes a no-op when target is 0.
+   */
+  public async getDepositsReserveTargetAt(blockTag: number): Promise<BigNumber> {
+    const lidoAddress = this.contractLido.address;
+    try {
+      const data = await this.provider.call(
+        { to: lidoAddress, data: GET_DEPOSITS_RESERVE_TARGET_SELECTOR },
+        blockTag,
+      );
+      const [target] = LIDO_EXTENSION_INTERFACE.decodeFunctionResult('getDepositsReserveTarget', data);
+      return BigNumber.from(target.toString());
+    } catch (error: unknown) {
+      this.logger.warn('getDepositsReserveTargetAt failed; falling back to 0 target', {
         service: LidoExtensionReader.SERVICE_LOG_NAME,
         lidoAddress,
         blockTag,

--- a/src/storage/contract-config/contract-config.service.ts
+++ b/src/storage/contract-config/contract-config.service.ts
@@ -14,6 +14,11 @@ export class ContractConfigStorageService {
   // Updated each contract-config tick from LidoExtensionReader.probe(); defaults to false.
   // Once observed true at the reader level, the latch keeps it true (a protocol cannot un-deploy SR-3).
   protected lidoSupportsDepositsReserve = false;
+  // Governance-set target the protocol refills depositsReserve to at every oracle report.
+  // Stored in wei (consistent with rewardsPerFrame and other ETH-amount fields). Defaults to 0
+  // so the rewards-projection netting is a no-op pre-SR-3 and on networks where governance
+  // hasn't set a target yet.
+  protected depositsReserveTarget: BigNumber = BigNumber.from(0);
   protected accountingOracleAddress: string;
   protected withdrawalVaultAddress: string;
   protected elRewardsVaultAddress: string;
@@ -65,6 +70,14 @@ export class ContractConfigStorageService {
 
   public setLidoSupportsDepositsReserve(lidoSupportsDepositsReserve: boolean): void {
     this.lidoSupportsDepositsReserve = lidoSupportsDepositsReserve;
+  }
+
+  public getDepositsReserveTarget(): BigNumber {
+    return this.depositsReserveTarget;
+  }
+
+  public setDepositsReserveTarget(depositsReserveTarget: BigNumber): void {
+    this.depositsReserveTarget = depositsReserveTarget;
   }
 
   public getAccountingOracleAddress() {

--- a/src/waiting-time/utils/calculate-frame-by-validator-balances.ts
+++ b/src/waiting-time/utils/calculate-frame-by-validator-balances.ts
@@ -2,13 +2,15 @@ import { BigNumber } from '@ethersproject/bignumber';
 
 type calculateFrameByValidatorBalancesArgs = {
   unfinilized: BigNumber;
-  rewardsPerFrame: BigNumber;
+  // Per-frame rewards rate net of the deposits-reserve refill claim — what's actually drainable
+  // to withdrawals each frame after governance siphons off the per-cycle reserve target.
+  rewardsAvailableForWithdrawals: BigNumber;
   currentFrame: number;
   frameBalances: Record<string, BigNumber>;
 };
 
 export const calculateFrameByValidatorBalances = (args: calculateFrameByValidatorBalancesArgs): number | null => {
-  const { frameBalances, unfinilized, rewardsPerFrame, currentFrame } = args;
+  const { frameBalances, unfinilized, rewardsAvailableForWithdrawals, currentFrame } = args;
   let unfinalizedAmount = unfinilized;
   let lastFrame = BigNumber.from(currentFrame);
 
@@ -23,7 +25,7 @@ export const calculateFrameByValidatorBalances = (args: calculateFrameByValidato
 
     // consider rewards only for future frames
     if (framesBetween.gte(0)) {
-      reduced = reduced.sub(framesBetween.mul(rewardsPerFrame));
+      reduced = reduced.sub(framesBetween.mul(rewardsAvailableForWithdrawals));
       lastFrame = BigNumber.from(frame);
     }
     unfinalizedAmount = reduced;

--- a/src/waiting-time/waiting-time.service.spec.ts
+++ b/src/waiting-time/waiting-time.service.spec.ts
@@ -76,6 +76,7 @@ describe('WaitingTimeService', () => {
             getMaxBalanceExitRequestedPerReportInEth: jest.fn(),
             getEpochsPerFrameVEBO: jest.fn(),
             getRequestTimestampMargin: jest.fn(),
+            getDepositsReserveTarget: jest.fn(),
             getLastUpdate: jest.fn(),
           },
         },
@@ -138,6 +139,8 @@ describe('WaitingTimeService', () => {
     jest.spyOn(contractConfig, 'getEpochsPerFrame').mockReturnValue(epochPerFrame);
     // 19,200 ETH = legacy 600 validator-cap × 32 ETH (lossless identity); both eras now stored in ETH.
     jest.spyOn(contractConfig, 'getMaxBalanceExitRequestedPerReportInEth').mockReturnValue(BigNumber.from(19_200));
+    // Default 0 target → deposits-reserve netting is a no-op, regression-safe for existing assertions.
+    jest.spyOn(contractConfig, 'getDepositsReserveTarget').mockReturnValue(BigNumber.from(0));
     jest.spyOn(contractConfig, 'getEpochsPerFrameVEBO').mockReturnValue(45);
     jest.spyOn(contractConfig, 'getRequestTimestampMargin').mockReturnValue(7680000);
     jest.spyOn(contractConfig, 'getLastUpdate').mockReturnValue(1);
@@ -268,7 +271,11 @@ describe('WaitingTimeService', () => {
     it(`check frames number`, () => {
       const countFrames = 3;
       const expectedResult = getFrameOfEpochMock(currentEpoch) + countFrames + 1;
-      const result = service.calculateFrameByRewardsOnly(BigNumber.from(rewardsPerFrame).mul(countFrames));
+      // unit test: pass rewardsPerFrame directly as the netted rate (target=0 case → no netting)
+      const result = service.calculateFrameByRewardsOnly(
+        BigNumber.from(rewardsPerFrame).mul(countFrames),
+        rewardsPerFrame,
+      );
 
       expect(result).toBe(expectedResult);
     });
@@ -361,6 +368,7 @@ describe('WaitingTimeService', () => {
       const result = await (service as any).calculateFrameExitValidatorsCaseWithVEBO(
         BigNumber.from('10000007748958196602737138'),
         '312321',
+        BigNumber.from(0), // rewardsAvailableForWithdrawals
       );
 
       expect(result).toBeNull();

--- a/src/waiting-time/waiting-time.service.spec.ts
+++ b/src/waiting-time/waiting-time.service.spec.ts
@@ -334,6 +334,66 @@ describe('WaitingTimeService', () => {
     });
   });
 
+  // Per-frame `depositsReserveTarget` is a recurring claim on rewards: at every oracle report
+  // the protocol siphons up to `target` ETH worth of fresh inflows to refill the reserve before
+  // the rest becomes available for withdrawals. The engine nets this out at the top of
+  // `calculateWithdrawalFrame` and threads `rewardsAvailableForWithdrawals` into all three
+  // projection cases.
+  describe('deposits-reserve future-projection netting', () => {
+    it(`target=0 (regression pin): netting is a no-op, calculateFrameByRewardsOnly identical to pre-fix`, () => {
+      // Mirror of the existing "check frames number" assertion above, made explicit as a
+      // regression pin. With target=0, rewardsAvailableForWithdrawals === rewardsPerFrame and
+      // the formula behaves exactly as it did before this change.
+      jest.spyOn(contractConfig, 'getDepositsReserveTarget').mockReturnValue(BigNumber.from(0));
+      const countFrames = 3;
+      const result = service.calculateFrameByRewardsOnly(
+        BigNumber.from(rewardsPerFrame).mul(countFrames),
+        rewardsPerFrame, // = rewardsAvailable when target=0
+      );
+      expect(result).toBe(getFrameOfEpochMock(currentEpoch) + countFrames + 1);
+    });
+
+    it(`target = rewardsPerFrame/2: rewardsOnly drain takes ~2× as long`, () => {
+      const halfRewards = BigNumber.from(rewardsPerFrame).div(2);
+      const countFrames = 3;
+      const result = service.calculateFrameByRewardsOnly(BigNumber.from(rewardsPerFrame).mul(countFrames), halfRewards);
+      // Half rate → 2× as many epochs to drain → 2 × countFrames frames from baseline
+      expect(result).toBe(getFrameOfEpochMock(currentEpoch) + countFrames * 2 + 1);
+    });
+
+    it(`target >= rewardsPerFrame: rewardsAvailable=0 → calculateFrameByRewardsOnly returns null`, () => {
+      const result = service.calculateFrameByRewardsOnly(BigNumber.from(rewardsPerFrame).mul(3), BigNumber.from(0));
+      expect(result).toBeNull();
+    });
+
+    it(`target>0 makes calculateWithdrawalFrame estimate strictly later than target=0 baseline`, async () => {
+      // Force exitValidators case (large unfinalized, no buffer). With target=0, baseline frame.
+      jest.spyOn(contractConfig, 'getDepositsReserveTarget').mockReturnValue(BigNumber.from(0));
+      const baseline = await service.calculateWithdrawalFrame({
+        unfinalized: BigNumber.from('100000007748958196602737138'),
+        buffer: BigNumber.from('0'),
+        vaultsBalance: BigNumber.from('0'),
+        requestTimestamp: lockedSystemTimestamp,
+        latestEpoch: '312321',
+      });
+
+      // With target = half of rewards, the rewards term in exitValidators' formula is halved
+      // → totalEthPerVEBOFrame is slightly smaller → VEBOFrames slightly larger → estimate later.
+      // The shift is small because exitChurn dominates over rewards in this regime, but it must
+      // not regress backward.
+      jest.spyOn(contractConfig, 'getDepositsReserveTarget').mockReturnValue(BigNumber.from(rewardsPerFrame).div(2));
+      const withTarget = await service.calculateWithdrawalFrame({
+        unfinalized: BigNumber.from('100000007748958196602737138'),
+        buffer: BigNumber.from('0'),
+        vaultsBalance: BigNumber.from('0'),
+        requestTimestamp: lockedSystemTimestamp,
+        latestEpoch: '312321',
+      });
+
+      expect(withTarget.frame).toBeGreaterThanOrEqual(baseline.frame);
+    });
+  });
+
   describe('exitValidators case behavior at maxBalanceExitRequestedPerReportInEth = 0', () => {
     // Per on-chain `_checkLimitValue(_, 0, type(uint16).max)`, governance can set the VEBO ETH
     // cap to 0 to halt new exit-request submissions (an emergency lever). The engine should

--- a/src/waiting-time/waiting-time.service.ts
+++ b/src/waiting-time/waiting-time.service.ts
@@ -200,8 +200,22 @@ export class WaitingTimeService {
     // exit validators + rewards (todo: add here case validators with withdrawable_epoch)
     let frameByExitValidatorsWithVEBO: CalculateWaitingTimeV2Result | null = null;
 
+    // Per-frame rewards rate net of the deposits-reserve refill claim. Governance sets a target
+    // value the protocol resets `depositsReserve` to at every oracle report; up to `target` ETH
+    // worth of fresh rewards is locked into the reserve before any of it becomes available for
+    // withdrawals. Conservative netting: assume worst-case where reserve fully drains between
+    // reports, so the per-frame claim is min(target, rewardsPerFrame). When target=0 (pre-SR-3
+    // or governance hasn't set one), this is a no-op.
+    const rewardsPerFrame = this.rewardsStorage.getRewardsPerFrame();
+    const depositsReserveTarget = this.contractConfig.getDepositsReserveTarget();
+    const reservedRefillPerFrame = depositsReserveTarget.gt(rewardsPerFrame) ? rewardsPerFrame : depositsReserveTarget;
+    const rewardsAvailableForWithdrawals = rewardsPerFrame.sub(reservedRefillPerFrame);
+
     // checked only rewards filling unfinalized
-    const frameByOnlyRewardsValue = this.calculateFrameByRewardsOnly(unfinalized.sub(fullBuffer));
+    const frameByOnlyRewardsValue = this.calculateFrameByRewardsOnly(
+      unfinalized.sub(fullBuffer),
+      rewardsAvailableForWithdrawals,
+    );
     if (frameByOnlyRewardsValue) {
       frameByOnlyRewards = {
         frame: frameByOnlyRewardsValue,
@@ -211,12 +225,11 @@ export class WaitingTimeService {
 
     // loop over all known frames with balances of withdrawing validators
     const frameBalances = this.validators.getFrameBalances();
-    const rewardsPerFrame = this.rewardsStorage.getRewardsPerFrame();
     const valueFrameValidatorsBalance = calculateFrameByValidatorBalances({
       unfinilized: unfinalized.sub(fullBuffer),
       frameBalances,
       currentFrame,
-      rewardsPerFrame,
+      rewardsAvailableForWithdrawals,
     });
 
     if (valueFrameValidatorsBalance) {
@@ -230,6 +243,7 @@ export class WaitingTimeService {
     const valueFrameExitValidators = await this.calculateFrameExitValidatorsCaseWithVEBO(
       unfinalized.sub(fullBuffer),
       latestEpoch,
+      rewardsAvailableForWithdrawals,
     );
 
     if (valueFrameExitValidators !== null) {
@@ -249,11 +263,12 @@ export class WaitingTimeService {
   private async calculateFrameExitValidatorsCaseWithVEBO(
     unfinalizedETH: BigNumber,
     latestEpoch: string,
+    rewardsAvailableForWithdrawals: BigNumber,
   ): Promise<number | null> {
     const churnLimit = this.validators.getChurnLimit();
     const epochPerFrame = this.contractConfig.getEpochsPerFrame();
     const epochsPerFrameVEBO = this.contractConfig.getEpochsPerFrameVEBO();
-    const rewardsPerEpoch = this.rewardsStorage.getRewardsPerFrame().div(epochPerFrame);
+    const rewardsPerEpoch = rewardsAvailableForWithdrawals.div(epochPerFrame);
 
     // ETH released by validator exits per epoch. Post-Electra churn limit is balance-based and
     // capped at 256 ETH/epoch by the protocol; multiplying by 32 ETH is a unit identity that
@@ -435,12 +450,11 @@ export class WaitingTimeService {
     } else return null;
   }
 
-  public calculateFrameByRewardsOnly(unfinalized: BigNumber) {
+  public calculateFrameByRewardsOnly(unfinalized: BigNumber, rewardsAvailableForWithdrawals: BigNumber) {
     const epochPerFrame = this.contractConfig.getEpochsPerFrame();
-    const rewardsPerFrame = this.rewardsStorage.getRewardsPerFrame();
-    if (rewardsPerFrame.eq(0)) return null;
+    if (rewardsAvailableForWithdrawals.eq(0)) return null;
 
-    const rewardsPerEpoch = rewardsPerFrame.div(epochPerFrame);
+    const rewardsPerEpoch = rewardsAvailableForWithdrawals.div(epochPerFrame);
     const onlyRewardPotentialEpoch = unfinalized.div(rewardsPerEpoch);
 
     return (


### PR DESCRIPTION
### Description

Refines wq-api waiting-time estimation under SR-3's `depositsReserve` mechanism. Builds on the SR-3 readiness PR (which subtracts `depositsReserve` from the current-block buffer in `BlockStateCacheService`); this PR closes the remaining accuracy gap in the **future-projection cases**.

The protocol resets `DEPOSITS_RESERVE_POSITION` to `depositsReserveTarget` at every oracle report, so up to `target` ETH worth of fresh inflows is locked into the reserve before the rest becomes available for withdrawals. The previous PR didn't account for this in projection formulas — it subtracted the reserve once at the buffer snapshot, but `calculateFrameByRewardsOnly`, `calculateFrameByValidatorBalances`, and `calculateFrameExitValidatorsCaseWithVEBO` continued to treat the full `rewardsPerFrame` as drainable to withdrawals.

This PR computes `rewardsAvailableForWithdrawals = rewardsPerFrame - min(target, rewardsPerFrame)` once at the top of `calculateWithdrawalFrame` and threads it through all three projection cases as a parameter. Conservative netting — assumes worst case where reserve fully drains between reports.

**Direction of correction**: estimates become slightly longer (or stay identical when `target=0`). Errs toward over-stating wait time, which is the safer bias for a withdrawal-time estimator.

### Why a separate PR

- **Surfaced post-validation**, after the SR-3 readiness PR was complete and Hoodi-validated.
- **Independent correctness improvement** — doesn't gate SR-3 mainnet readiness. The parent PR is correct for `target = 0` (current Hoodi state, expected mainnet day-0 state per LIP-35 "initial value to be proposed once migration pacing is agreed").
- **Cleaner review surface**: parent PR = "make wq-api work post-SR-3"; this PR = "improve accuracy when governance raises the reserve target".
- On Hoodi today (target=0): both PRs produce **identical** runtime output. The improvement only matters when governance sets a non-zero target.

### Code review notes

- **Conservative bias is intentional.** Realistic per-frame reserve refill claim is `min(target, totalInflowPerFrame)` where `totalInflowPerFrame` would also include CL exits, not just rewards. We net only against rewards, simpler and more pessimistic. On steady-state mainnet the two are within ~10% of each other; the over-statement is acceptable for a withdrawal-time estimator.

- **One-tick lag after SR-3 detection** is intentional. The contract-config job gates `getDepositsReserveTargetAt(...)` on the previous-tick storage flag (`getLidoSupportsDepositsReserve()`):
  - Pre-SR-3: target call skipped → no `warn`-spam from the reader's defensive try/catch
  - First tick after SR-3 detection: previous flag was still false → target stays at default 0 → netting is a no-op for that one tick
  - Subsequent ticks: target fetched in parallel with other reads
  
  The lag tick is safe because `target=0` produces the same estimates as pre-SR-3 (no-op netting). Alternative (eager fetch with conditional warn-suppression in the reader) was rejected as more complex without a meaningful win — target changes only via governance call, missing one tick is ~minutes.

- **`target=0` is the regression-pin invariant.** All 66 pre-existing test outputs stayed unchanged across the storage rename and projection refactor. The new regime test "target=0 (regression pin)" makes this explicit so a future PR removing the netting can't accidentally pass tests by leaving only `target=0` cases.

- **Storage unit is wei** (consistent with `rewardsPerFrame`). Differs from `maxBalanceExitRequestedPerReportInEth` which is whole ETH (because the on-chain semantics differs — uint16-capped count→ETH equivalence). Different field, different convention, justified case-by-case in the storage class comments.

- **Reuses existing infrastructure** rather than introducing parallel readers/flags: same `LidoExtensionReader`, same `lidoSupportsDepositsReserve` flag. The new `getDepositsReserveTargetAt` is a sibling method on the same proxy as `getDepositsReserveAt` — no separate probe needed (they ship together in the SR-3 Lido upgrade).

### Testing notes

**New tests:**

| File | Cases | Coverage |
|---|---|---|
| `lido-extension-reader.spec.ts` | 3 | `getDepositsReserveTargetAt` — decoded uint256 + blockTag pass-through, revert returns 0 + warn log, sibling-not-alias selector check |
| `waiting-time.service.spec.ts` | 4 | regression pin at `target=0`, half-rate scaling at `target=rewardsPerFrame/2`, null at `rewardsAvailable=0`, integration through `calculateWithdrawalFrame` (target>0 estimate ≥ baseline) |

**Hoodi e2e validation** :
Service deployed against post-SR-3 Hoodi. Contract-config job log line shows
new field `depositsReserveTarget: "0"` populated alongside the existing SR-3
fields. Hoodi's governance hasn't set a non-zero target, so the netting is a
no-op and runtime behavior is byte-identical to the parent PR — confirming
the regression-pin invariant in tests.

**Edge cases pinned by tests:**
- `target = 0`: full no-op (regression pin)
- `target < rewardsPerFrame`: linear scaling of drain time (1/2 rate → 2× time)
- `target ≥ rewardsPerFrame`: rewardsOnly returns null; engine takes min over remaining cases
- `calculateWithdrawalFrame` integration: target>0 produces estimate that is at least as late as the target=0 baseline (conservative direction)

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation.
- [ ] Affects / requires changes in other services.
