### PR TITLE
Feature/hardfork eip 8080

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -28,3 +28,9 @@ EL_RPC_URLS=
 
 # CHAIN_ID
 CHAIN_ID=5
+
+# EIP-8080 ("Let exits use the consolidation queue") activation epoch.
+# Leave empty for legacy single-queue exit-throughput modelling. Set to the network's
+# fork epoch (after that epoch lands on-chain) to enable the up-to-2.5x exit-throughput
+# uplift in the `exitValidators` waiting-time case. See ADR-0002 in the wq-api vault.
+EIP_8080_FORK_EPOCH=

--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -28,7 +28,7 @@ export class EnvironmentVariables {
   @IsNumber()
   @Min(1)
   @Transform(toNumber({ defaultValue: 3000 }))
-  PORT: number = 3000;
+  PORT = 3000;
 
   @IsOptional()
   @IsString()
@@ -38,19 +38,19 @@ export class EnvironmentVariables {
   @IsNumber()
   @Min(1)
   @Transform(toNumber({ defaultValue: 5 }))
-  GLOBAL_THROTTLE_TTL: number = 5;
+  GLOBAL_THROTTLE_TTL = 5;
 
   @IsOptional()
   @IsNumber()
   @Min(1)
   @Transform(toNumber({ defaultValue: 100 }))
-  GLOBAL_THROTTLE_LIMIT: number = 100;
+  GLOBAL_THROTTLE_LIMIT = 100;
 
   @IsOptional()
   @IsNumber()
   @Min(1)
   @Transform(toNumber({ defaultValue: 1 }))
-  GLOBAL_CACHE_TTL: number = 1;
+  GLOBAL_CACHE_TTL = 1;
 
   @IsOptional()
   @IsString()
@@ -114,6 +114,16 @@ export class EnvironmentVariables {
   @IsOptional()
   @IsString()
   CUSTOM_NETWORK_FILE_NAME: string;
+
+  // EIP-8080 ("Let exits use the consolidation queue") activation epoch. When set, exit-churn
+  // throughput in the `exitValidators` waiting-time case can draw from idle consolidation
+  // churn — see ADR-0002. Empty/unset means the legacy single-queue formula applies; this is
+  // the safe default because applying EIP-8080 logic before the fork over-promises users.
+  @IsOptional()
+  @Transform(({ value }) => (value === '' || value == null ? null : Number(value)))
+  @IsNumber()
+  @Min(0)
+  EIP_8080_FORK_EPOCH: number | null = null;
 }
 export const ENV_KEYS = Object.keys(new EnvironmentVariables());
 

--- a/src/common/consensus-provider/consensus-client.service.ts
+++ b/src/common/consensus-provider/consensus-client.service.ts
@@ -1,7 +1,11 @@
 import { ConsensusService as ConsensusProviderService } from '@lido-nestjs/consensus';
 import { Injectable } from '@nestjs/common';
 import { processJsonStreamBeaconState } from './utils/process-json-stream-beacon-state';
-import { BeaconStateSweepData, PendingPartialWithdrawal } from './consensus-provider.types';
+import {
+  BeaconStateExitConsolidationQueueData,
+  BeaconStateSweepData,
+  PendingPartialWithdrawal,
+} from './consensus-provider.types';
 import {
   API_GET_EXECUTION_PAYLOAD_ENVELOPE_URL,
   API_GET_PENDING_PARTIAL_WITHDRAWALS_URL,
@@ -32,6 +36,15 @@ export class ConsensusClientService {
     ]);
 
     return result as BeaconStateSweepData;
+  }
+
+  // Reads the EIP-8080-relevant queue fields off beacon state via the same streaming-pick
+  // mechanism used for sweep state. Single endpoint, single AbortController surface.
+  public async getStateExitConsolidationQueueData(stateId: string): Promise<BeaconStateExitConsolidationQueueData> {
+    const stream = await this.consensusService.fetchStream(API_GET_STATE_URL(stateId));
+    const result = await processJsonStreamBeaconState(stream, ['earliest_exit_epoch', 'earliest_consolidation_epoch']);
+
+    return result as BeaconStateExitConsolidationQueueData;
   }
 
   public async getPendingPartialWithdrawals(stateId: string): Promise<PendingPartialWithdrawal[]> {

--- a/src/common/consensus-provider/consensus-provider.types.ts
+++ b/src/common/consensus-provider/consensus-provider.types.ts
@@ -22,12 +22,20 @@ export interface BeaconStateSweepData {
   latest_withdrawals_root?: string;
 }
 
+// Subset of BeaconState fields used to model EIP-8080 ("Let exits use the consolidation
+// queue"). Both fields are present on Electra+ chains; see consensus-specs Electra
+// beacon-chain.md. Strings to match the over-the-wire representation.
+export interface BeaconStateExitConsolidationQueueData {
+  earliest_exit_epoch?: string;
+  earliest_consolidation_epoch?: string;
+}
+
 /**
  * Spec reference:
  * https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#beaconstate
  * included only used properties
  */
-export interface BeaconState extends BeaconStateSweepData {
+export interface BeaconState extends BeaconStateSweepData, BeaconStateExitConsolidationQueueData {
   pending_partial_withdrawals: PendingPartialWithdrawal[];
   validators: Validator[];
   balances: string[];

--- a/src/jobs/validators/utils/get-churn-limit.ts
+++ b/src/jobs/validators/utils/get-churn-limit.ts
@@ -5,16 +5,22 @@ const MIN_ACTIVATION_BALANCE = BigNumber.from('32000000000'); // 32 ETH in Gwei
 const MAX_PER_EPOCH_CHURN_LIMIT = BigNumber.from('256000000000'); // 256 ETH in Gwei
 const CHURN_LIMIT_QUOTIENT = BigNumber.from('65536');
 
+// Total balance churn budget per epoch in Gwei: max(floor, totalActiveBalance / quotient).
+// Same formula as the consensus spec `get_balance_churn_limit`. Returned uncapped so callers
+// can derive both the exit-side and consolidation-side allocations from a single base.
+function getBalanceChurnLimitGwei(totalActiveBalanceGwei: BigNumber): BigNumber {
+  const minLimit = MIN_PER_EPOCH_CHURN_LIMIT.mul(MIN_ACTIVATION_BALANCE);
+  const dynamicLimit = totalActiveBalanceGwei.div(CHURN_LIMIT_QUOTIENT);
+  return dynamicLimit.gt(minLimit) ? dynamicLimit : minLimit;
+}
+
 /**
  * Calculates the churn limit (in Gwei) based on total active balance.
  * Pectra-style stake-based churn limit with min/max bounds.
  */
 export function getChurnLimitGwei(totalActiveBalanceGwei: BigNumber): BigNumber {
-  const minLimit = MIN_PER_EPOCH_CHURN_LIMIT.mul(MIN_ACTIVATION_BALANCE);
-  const dynamicLimit = totalActiveBalanceGwei.div(CHURN_LIMIT_QUOTIENT);
-  const maxedLimit = dynamicLimit.gt(minLimit) ? dynamicLimit : minLimit;
-
-  return maxedLimit.gt(MAX_PER_EPOCH_CHURN_LIMIT) ? MAX_PER_EPOCH_CHURN_LIMIT : maxedLimit;
+  const balanceChurn = getBalanceChurnLimitGwei(totalActiveBalanceGwei);
+  return balanceChurn.gt(MAX_PER_EPOCH_CHURN_LIMIT) ? MAX_PER_EPOCH_CHURN_LIMIT : balanceChurn;
 }
 
 /**
@@ -22,4 +28,14 @@ export function getChurnLimitGwei(totalActiveBalanceGwei: BigNumber): BigNumber 
  */
 export function getChurnLimit(totalActiveBalanceGwei: BigNumber) {
   return getChurnLimitGwei(totalActiveBalanceGwei).div(MIN_ACTIVATION_BALANCE);
+}
+
+// Per Electra spec, consolidation churn = total balance churn − exit-side churn. When the
+// exit-side cap is binding (large total active balance), consolidation gets the leftover;
+// when balance churn is below the exit cap, consolidation gets zero. EIP-8080 routes idle
+// consolidation churn back to exits, so this is the budget available for that uplift.
+export function getConsolidationChurnLimitGwei(totalActiveBalanceGwei: BigNumber): BigNumber {
+  const balanceChurn = getBalanceChurnLimitGwei(totalActiveBalanceGwei);
+  const exitChurn = getChurnLimitGwei(totalActiveBalanceGwei);
+  return balanceChurn.sub(exitChurn);
 }

--- a/src/jobs/validators/validators.service.ts
+++ b/src/jobs/validators/validators.service.ts
@@ -24,7 +24,7 @@ import { hasCompoundingWithdrawalCredential, hasEth1WithdrawalCredential } from 
 import { IndexedValidator, ResponseValidatorsData } from '../../common/consensus-provider/consensus-provider.types';
 import { SweepService, WithdrawalSweepState } from '../../common/sweep';
 import { toEth } from '../../common/utils/to-eth';
-import { getChurnLimit } from './utils/get-churn-limit';
+import { getChurnLimit, getChurnLimitGwei, getConsolidationChurnLimitGwei } from './utils/get-churn-limit';
 
 export class ValidatorsService {
   static SERVICE_LOG_NAME = 'validators';
@@ -172,6 +172,15 @@ export class ValidatorsService {
 
         this.validatorsStorageService.setActiveValidatorsCount(activeValidatorCount);
         this.validatorsStorageService.setChurnLimit(getChurnLimit(totalActiveBalance).toNumber());
+        // EIP-8080 inputs: store the Gwei-form churn budgets too, keyed off the same
+        // total-active-balance that drove the legacy count form. Two separate values so
+        // the waiting-time engine can model exit-vs-consolidation queue dynamics without
+        // re-deriving them on every request.
+        this.validatorsStorageService.setExitChurnPerEpochGwei(getChurnLimitGwei(totalActiveBalance));
+        this.validatorsStorageService.setConsolidationChurnPerEpochGwei(
+          getConsolidationChurnLimitGwei(totalActiveBalance),
+        );
+        await this.fetchAndSetExitConsolidationQueueState();
         this.validatorsStorageService.setTotalValidatorsCount(indexedValidators.length);
         this.validatorsStorageService.setMaxExitEpoch(maxExitEpoch);
         await this.findAndSetLidoValidatorsWithdrawableBalances(indexedValidators);
@@ -295,6 +304,26 @@ export class ValidatorsService {
         this.logAnalyticsAboutFrameBalances();
       },
     );
+  }
+
+  // EIP-8080: fetch beacon-state queue heads needed to decide whether exits can draw on
+  // idle consolidation churn. Pre-Electra/old-spec chains may omit the fields entirely;
+  // missing values are treated as null and downstream falls back to legacy formula.
+  // Errors are caught and logged so a single failing read doesn't poison the whole job
+  // tick — same posture as wrapJob's own error handling.
+  protected async fetchAndSetExitConsolidationQueueState(stateId = 'head'): Promise<void> {
+    try {
+      const state = await this.consensusClientService.getStateExitConsolidationQueueData(stateId);
+      this.validatorsStorageService.setEarliestExitEpoch(state.earliest_exit_epoch ?? null);
+      this.validatorsStorageService.setEarliestConsolidationEpoch(state.earliest_consolidation_epoch ?? null);
+    } catch (error) {
+      this.logger.warn('failed to read EIP-8080 queue state from beacon, falling back to null', {
+        service: ValidatorsService.SERVICE_LOG_NAME,
+        error,
+      });
+      this.validatorsStorageService.setEarliestExitEpoch(null);
+      this.validatorsStorageService.setEarliestConsolidationEpoch(null);
+    }
   }
 
   protected async getWithdrawalSweepState(stateId = 'head'): Promise<WithdrawalSweepState> {

--- a/src/storage/validators/validators-cache.service.ts
+++ b/src/storage/validators/validators-cache.service.ts
@@ -11,7 +11,19 @@ export class ValidatorsCacheService {
   static CACHE_FILE_NAME = 'validators-state.txt';
   static CACHE_DIR = 'cache';
   static CACHE_DATA_DIVIDER = '|';
-  static CACHE_DATA_LENGTH = 6;
+  // Positional pipe-delimited format. Bumping length invalidates older caches on first
+  // boot — they self-heal on the next live validators-job pass. Layout (in order):
+  //   0: activeValidatorsCount
+  //   1: maxExitEpoch
+  //   2: lastUpdate
+  //   3: frameBalances (JSON)
+  //   4: sweepMeanEpochs
+  //   5: churnLimit (legacy 32-ETH-equivalent count)
+  //   6: exitChurnPerEpochGwei            (EIP-8080)
+  //   7: consolidationChurnPerEpochGwei   (EIP-8080)
+  //   8: earliestExitEpoch                (EIP-8080)
+  //   9: earliestConsolidationEpoch       (EIP-8080)
+  static CACHE_DATA_LENGTH = 10;
   static SERVICE_LOG_NAME = 'validators cache';
   static CACHE_INVALIDATE_TIME = 3 * 3600; // 3 hours
 
@@ -57,6 +69,10 @@ export class ValidatorsCacheService {
       this.validatorsStorage.setFrameBalances(this.parseFrameBalances(data[3]));
       this.validatorsStorage.setSweepMeanEpochs(Number(data[4]));
       this.validatorsStorage.setChurnLimit(Number(data[5]));
+      this.validatorsStorage.setExitChurnPerEpochGwei(this.parseBigNumberOrNull(data[6]));
+      this.validatorsStorage.setConsolidationChurnPerEpochGwei(this.parseBigNumberOrNull(data[7]));
+      this.validatorsStorage.setEarliestExitEpoch(this.parseStringOrNull(data[8]));
+      this.validatorsStorage.setEarliestConsolidationEpoch(this.parseStringOrNull(data[9]));
 
       this.logger.log(`success initialize from cache file ${cacheFileName}`, {
         service: ValidatorsCacheService.SERVICE_LOG_NAME,
@@ -82,6 +98,10 @@ export class ValidatorsCacheService {
       stringifyFrameBalances(this.validatorsStorage.getFrameBalances()),
       this.validatorsStorage.getSweepMeanEpochs(),
       this.validatorsStorage.getChurnLimit(),
+      this.serializeBigNumberOrNull(this.validatorsStorage.getExitChurnPerEpochGwei()),
+      this.serializeBigNumberOrNull(this.validatorsStorage.getConsolidationChurnPerEpochGwei()),
+      this.serializeStringOrNull(this.validatorsStorage.getEarliestExitEpoch()),
+      this.serializeStringOrNull(this.validatorsStorage.getEarliestConsolidationEpoch()),
     ].join(ValidatorsCacheService.CACHE_DATA_DIVIDER);
     await writeFile(cacheFileName, data);
     this.logger.log(`success save to file ${cacheFileName}`, { service: ValidatorsCacheService.SERVICE_LOG_NAME });
@@ -96,5 +116,27 @@ export class ValidatorsCacheService {
     return Object.keys(frameBalances).reduce((acc, key) => {
       return { ...acc, [key]: BigNumber.from(frameBalances[key]) };
     }, {});
+  }
+
+  // Sentinel "null" string used for optional EIP-8080 fields not yet populated. Avoids
+  // empty-segment ambiguity in the pipe-delimited format.
+  protected static NULL_SENTINEL = 'null';
+
+  protected serializeBigNumberOrNull(value: BigNumber | null): string {
+    return value === null ? ValidatorsCacheService.NULL_SENTINEL : value.toString();
+  }
+
+  protected parseBigNumberOrNull(raw: string): BigNumber | null {
+    if (raw === ValidatorsCacheService.NULL_SENTINEL || raw === '' || raw == null) return null;
+    return BigNumber.from(raw);
+  }
+
+  protected serializeStringOrNull(value: string | null): string {
+    return value === null ? ValidatorsCacheService.NULL_SENTINEL : value;
+  }
+
+  protected parseStringOrNull(raw: string): string | null {
+    if (raw === ValidatorsCacheService.NULL_SENTINEL || raw === '' || raw == null) return null;
+    return raw;
   }
 }

--- a/src/storage/validators/validators.service.ts
+++ b/src/storage/validators/validators.service.ts
@@ -12,6 +12,14 @@ export class ValidatorsStorageService {
   protected churnLimit: number;
   protected withdrawableLidoValidatorIds: string[] = [];
 
+  // EIP-8080 inputs. Populated by the validators job from beacon-state and from the
+  // total-active-balance derivation (see get-churn-limit utils). Default to null so the
+  // waiting-time engine can fall back to the legacy formula until the job has run once.
+  protected exitChurnPerEpochGwei: BigNumber | null = null;
+  protected consolidationChurnPerEpochGwei: BigNumber | null = null;
+  protected earliestExitEpoch: string | null = null;
+  protected earliestConsolidationEpoch: string | null = null;
+
   /**
    * Get max exit epoch for all validators
    * @returns max exit epoch string
@@ -106,5 +114,37 @@ export class ValidatorsStorageService {
 
   public getWithdrawableLidoValidatorIds() {
     return this.withdrawableLidoValidatorIds;
+  }
+
+  public setExitChurnPerEpochGwei(value: BigNumber | null) {
+    this.exitChurnPerEpochGwei = value;
+  }
+
+  public getExitChurnPerEpochGwei(): BigNumber | null {
+    return this.exitChurnPerEpochGwei;
+  }
+
+  public setConsolidationChurnPerEpochGwei(value: BigNumber | null) {
+    this.consolidationChurnPerEpochGwei = value;
+  }
+
+  public getConsolidationChurnPerEpochGwei(): BigNumber | null {
+    return this.consolidationChurnPerEpochGwei;
+  }
+
+  public setEarliestExitEpoch(value: string | null) {
+    this.earliestExitEpoch = value;
+  }
+
+  public getEarliestExitEpoch(): string | null {
+    return this.earliestExitEpoch;
+  }
+
+  public setEarliestConsolidationEpoch(value: string | null) {
+    this.earliestConsolidationEpoch = value;
+  }
+
+  public getEarliestConsolidationEpoch(): string | null {
+    return this.earliestConsolidationEpoch;
   }
 }

--- a/src/waiting-time/utils/compute-effective-exit-churn.spec.ts
+++ b/src/waiting-time/utils/compute-effective-exit-churn.spec.ts
@@ -1,0 +1,121 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { computeEffectiveExitChurnPerEpochGwei } from './compute-effective-exit-churn';
+
+describe('computeEffectiveExitChurnPerEpochGwei', () => {
+  // 256 ETH in Gwei — current legacy hard cap on exit churn (see get-churn-limit.ts).
+  const exitChurn256 = BigNumber.from('256000000000');
+  // 432 ETH in Gwei — typical post-Electra consolidation churn cap on mainnet.
+  const consolidationChurn432 = BigNumber.from('432000000000');
+
+  it('returns legacy exit churn unchanged when feature flag is off, regardless of queue state', () => {
+    const result = computeEffectiveExitChurnPerEpochGwei({
+      isExitViaConsolidationActive: false,
+      earliestExitEpoch: BigNumber.from(1_000_000),
+      earliestConsolidationEpoch: BigNumber.from(500_000),
+      exitChurnPerEpochGwei: exitChurn256,
+      consolidationChurnPerEpochGwei: consolidationChurn432,
+    });
+
+    expect(result.eq(exitChurn256)).toBe(true);
+  });
+
+  it('returns legacy exit churn when queues are equal — EIP-8080 branch is strictly greater-than', () => {
+    const result = computeEffectiveExitChurnPerEpochGwei({
+      isExitViaConsolidationActive: true,
+      earliestExitEpoch: BigNumber.from(500_000),
+      earliestConsolidationEpoch: BigNumber.from(500_000),
+      exitChurnPerEpochGwei: exitChurn256,
+      consolidationChurnPerEpochGwei: consolidationChurn432,
+    });
+
+    expect(result.eq(exitChurn256)).toBe(true);
+  });
+
+  it('returns legacy exit churn when consolidation queue is longer than exit queue', () => {
+    const result = computeEffectiveExitChurnPerEpochGwei({
+      isExitViaConsolidationActive: true,
+      earliestExitEpoch: BigNumber.from(500_000),
+      earliestConsolidationEpoch: BigNumber.from(600_000),
+      exitChurnPerEpochGwei: exitChurn256,
+      consolidationChurnPerEpochGwei: consolidationChurn432,
+    });
+
+    expect(result.eq(exitChurn256)).toBe(true);
+  });
+
+  it('adds consolidation churn scaled by 3/2 when exit queue is longer than consolidation queue', () => {
+    // 256 + 432 × 3/2 = 256 + 648 = 904 ETH/epoch
+    const expected = BigNumber.from('904000000000');
+
+    const result = computeEffectiveExitChurnPerEpochGwei({
+      isExitViaConsolidationActive: true,
+      earliestExitEpoch: BigNumber.from(600_000),
+      earliestConsolidationEpoch: BigNumber.from(500_000),
+      exitChurnPerEpochGwei: exitChurn256,
+      consolidationChurnPerEpochGwei: consolidationChurn432,
+    });
+
+    expect(result.eq(expected)).toBe(true);
+  });
+
+  it('handles zero consolidation churn (queue at floor) — effective equals legacy exit churn', () => {
+    const result = computeEffectiveExitChurnPerEpochGwei({
+      isExitViaConsolidationActive: true,
+      earliestExitEpoch: BigNumber.from(600_000),
+      earliestConsolidationEpoch: BigNumber.from(500_000),
+      exitChurnPerEpochGwei: exitChurn256,
+      consolidationChurnPerEpochGwei: BigNumber.from(0),
+    });
+
+    expect(result.eq(exitChurn256)).toBe(true);
+  });
+
+  it('uses BigNumber integer division — multiply-before-divide preserves precision on odd inputs', () => {
+    // consolidation = 5 Gwei; 5 × 3 = 15; 15 / 2 = 7 (integer division). Multiply-first
+    // would give 7; divide-first (5 / 2 = 2; 2 × 3 = 6) would give 6. Pin the order.
+    const result = computeEffectiveExitChurnPerEpochGwei({
+      isExitViaConsolidationActive: true,
+      earliestExitEpoch: BigNumber.from(600_000),
+      earliestConsolidationEpoch: BigNumber.from(500_000),
+      exitChurnPerEpochGwei: BigNumber.from(0),
+      consolidationChurnPerEpochGwei: BigNumber.from(5),
+    });
+
+    expect(result.eq(BigNumber.from(7))).toBe(true);
+  });
+
+  it('matches the EIP-8080 motivation example: ~256 → ~688 ETH/epoch ceiling', () => {
+    // The EIP cites a 2.5x improvement: from 256 ETH/epoch up to ~688 ETH/epoch under
+    // current parameters. With consolidation churn of 288 ETH/epoch (the value implied
+    // by the EIP's "688 = 256 + 288 × 3/2" arithmetic), the effective exit-side budget
+    // should hit ~688 ETH/epoch when the exit queue is ahead.
+    const consolidationChurn288 = BigNumber.from('288000000000');
+    const expected = BigNumber.from('688000000000');
+
+    const result = computeEffectiveExitChurnPerEpochGwei({
+      isExitViaConsolidationActive: true,
+      earliestExitEpoch: BigNumber.from(600_000),
+      earliestConsolidationEpoch: BigNumber.from(500_000),
+      exitChurnPerEpochGwei: exitChurn256,
+      consolidationChurnPerEpochGwei: consolidationChurn288,
+    });
+
+    expect(result.eq(expected)).toBe(true);
+  });
+
+  it('does not mutate input BigNumbers', () => {
+    const exitIn = BigNumber.from('256000000000');
+    const consolidationIn = BigNumber.from('432000000000');
+
+    computeEffectiveExitChurnPerEpochGwei({
+      isExitViaConsolidationActive: true,
+      earliestExitEpoch: BigNumber.from(600_000),
+      earliestConsolidationEpoch: BigNumber.from(500_000),
+      exitChurnPerEpochGwei: exitIn,
+      consolidationChurnPerEpochGwei: consolidationIn,
+    });
+
+    expect(exitIn.eq('256000000000')).toBe(true);
+    expect(consolidationIn.eq('432000000000')).toBe(true);
+  });
+});

--- a/src/waiting-time/utils/compute-effective-exit-churn.ts
+++ b/src/waiting-time/utils/compute-effective-exit-churn.ts
@@ -1,0 +1,65 @@
+import { BigNumber } from '@ethersproject/bignumber';
+
+export type ComputeEffectiveExitChurnArgs = {
+  // Whether the chain is past the EIP-8080 fork epoch. Pre-fork callers must pass `false`
+  // to preserve the legacy single-queue formula; otherwise the model over-promises and
+  // user-facing finalisation estimates land sooner than the chain can actually deliver.
+  isExitViaConsolidationActive: boolean;
+
+  // Beacon-state fields read by the validators job. Absolute epoch numbers (BigNumber to
+  // tolerate the post-Electra range without precision loss).
+  earliestExitEpoch: BigNumber;
+  earliestConsolidationEpoch: BigNumber;
+
+  // Per-epoch churn budgets in Gwei, as exposed by the beacon chain spec. Caller is
+  // responsible for sourcing these consistently with the same beacon-state read used for
+  // earliestExitEpoch / earliestConsolidationEpoch — otherwise the EIP-8080 branch
+  // operates on an inconsistent snapshot.
+  exitChurnPerEpochGwei: BigNumber;
+  consolidationChurnPerEpochGwei: BigNumber;
+};
+
+// Per EIP-8080 spec rationale, exit balance routed through the consolidation queue is
+// scaled by 2/3 to preserve weak-subjectivity equivalence between the two churn types.
+const WEAK_SUBJECTIVITY_NUM = BigNumber.from(2);
+const WEAK_SUBJECTIVITY_DEN = BigNumber.from(3);
+
+// Returns the effective per-epoch exit-side churn budget in Gwei, modelling EIP-8080.
+//
+// Pre-fork (or flag off): returns exitChurnPerEpochGwei verbatim — legacy behaviour.
+// Post-fork, when the exit queue is ahead of the consolidation queue: exits also draw
+// from consolidation churn, so the total effective budget is exit-churn plus the
+// 2/3-scaled consolidation-churn allocation. This is the same direction (× 3/2) implied
+// by the EIP's `2 * exit_balance // 3` scaling: each unit of consolidation churn
+// processes 1.5 units of equivalent exit-side balance.
+//
+// Post-fork, when the consolidation queue is ahead of (or equal to) the exit queue:
+// EIP-8080's branch does not fire — exits stay on the exit queue. Returns
+// exitChurnPerEpochGwei.
+export const computeEffectiveExitChurnPerEpochGwei = (args: ComputeEffectiveExitChurnArgs): BigNumber => {
+  const {
+    isExitViaConsolidationActive,
+    earliestExitEpoch,
+    earliestConsolidationEpoch,
+    exitChurnPerEpochGwei,
+    consolidationChurnPerEpochGwei,
+  } = args;
+
+  if (!isExitViaConsolidationActive) {
+    return exitChurnPerEpochGwei;
+  }
+
+  if (earliestExitEpoch.lte(earliestConsolidationEpoch)) {
+    return exitChurnPerEpochGwei;
+  }
+
+  // Convert consolidation-side budget into its exit-side equivalent. EIP-8080 scales
+  // routed exits by 2/3 of their balance, so for a fixed consolidation churn budget B,
+  // the equivalent exit-side throughput is B × (3/2). BigNumber integer arithmetic:
+  // multiply first, divide second to preserve precision.
+  const consolidationAsExitEquivalent = consolidationChurnPerEpochGwei
+    .mul(WEAK_SUBJECTIVITY_DEN)
+    .div(WEAK_SUBJECTIVITY_NUM);
+
+  return exitChurnPerEpochGwei.add(consolidationAsExitEquivalent);
+};

--- a/src/waiting-time/utils/index.ts
+++ b/src/waiting-time/utils/index.ts
@@ -2,3 +2,4 @@ export * from './validate-time-response-with-fallback';
 export * from './calculate-unfinalized-eth-to-requestId';
 export * from './calculate-frame-by-validator-balances';
 export * from './calculate-sweeping-mean';
+export * from './compute-effective-exit-churn';

--- a/src/waiting-time/waiting-time.service.spec.ts
+++ b/src/waiting-time/waiting-time.service.spec.ts
@@ -14,8 +14,11 @@ import { SECONDS_PER_SLOT, SLOTS_PER_EPOCH } from 'common/genesis-time';
 import { WaitingTimeCalculationType } from './waiting-time.types';
 import { PrometheusService } from '../common/prometheus';
 import { BlockStateCacheService } from './block-state-cache.service';
+import { ConfigService } from '../common/config';
 
-jest.mock('common/config', () => ({}));
+jest.mock('common/config', () => ({
+  ConfigService: class {},
+}));
 
 describe('WaitingTimeService', () => {
   let moduleRef: TestingModule;
@@ -25,6 +28,7 @@ describe('WaitingTimeService', () => {
   let genesisTimeService: GenesisTimeService;
   let validatorsStorage: ValidatorsStorageService;
   let queueInfoStorageService: QueueInfoStorageService;
+  let configService: ConfigService;
 
   // constants
   const genesisTime = 1606824023;
@@ -102,6 +106,10 @@ describe('WaitingTimeService', () => {
             getSweepMeanEpochs: jest.fn(),
             getMaxExitEpoch: jest.fn(),
             getLastUpdate: jest.fn(),
+            getExitChurnPerEpochGwei: jest.fn(),
+            getConsolidationChurnPerEpochGwei: jest.fn(),
+            getEarliestExitEpoch: jest.fn(),
+            getEarliestConsolidationEpoch: jest.fn(),
           },
         },
         {
@@ -124,6 +132,12 @@ describe('WaitingTimeService', () => {
           provide: PrometheusService,
           useValue: {},
         },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -133,6 +147,7 @@ describe('WaitingTimeService', () => {
     genesisTimeService = moduleRef.get<GenesisTimeService>(GenesisTimeService);
     validatorsStorage = moduleRef.get<ValidatorsStorageService>(ValidatorsStorageService);
     queueInfoStorageService = moduleRef.get<QueueInfoStorageService>(QueueInfoStorageService);
+    configService = moduleRef.get<ConfigService>(ConfigService);
 
     // mocks
     jest.spyOn(contractConfig, 'getInitialEpoch').mockReturnValue(initialEpoch);
@@ -154,6 +169,15 @@ describe('WaitingTimeService', () => {
     jest.spyOn(validatorsStorage, 'getSweepMeanEpochs').mockReturnValue(1041);
     jest.spyOn(validatorsStorage, 'getChurnLimit').mockReturnValue(8);
     jest.spyOn(validatorsStorage, 'getLastUpdate').mockReturnValue(1);
+    // EIP-8080 inputs default to null = "validators job hasn't populated them yet" =
+    // legacy formula path. Direction-of-error: matches pre-EIP-8080 behaviour exactly.
+    jest.spyOn(validatorsStorage, 'getExitChurnPerEpochGwei').mockReturnValue(null);
+    jest.spyOn(validatorsStorage, 'getConsolidationChurnPerEpochGwei').mockReturnValue(null);
+    jest.spyOn(validatorsStorage, 'getEarliestExitEpoch').mockReturnValue(null);
+    jest.spyOn(validatorsStorage, 'getEarliestConsolidationEpoch').mockReturnValue(null);
+    // EIP_8080_FORK_EPOCH unset = legacy path. Tests that exercise the post-fork branch
+    // override this in their own scope.
+    jest.spyOn(configService, 'get').mockImplementation(() => null as never);
     jest.spyOn(queueInfoStorageService, 'getRequests').mockReturnValue([]);
     jest.spyOn(queueInfoStorageService, 'getLastUpdate').mockReturnValue(1);
     jest.spyOn(service, 'getFrameIsBunker').mockReturnValue(null);
@@ -462,6 +486,133 @@ describe('WaitingTimeService', () => {
       // pre-fix at the same inputs would have computed churnLimit = 24 from
       // getActiveValidatorsCount = 1.6M, denominator = 32 * 24 = 768 ETH/epoch (above the
       // real 256 ETH/epoch cap), and returned 10 days — over-promising.
+    });
+  });
+
+  // EIP-8080 ("Let exits use the consolidation queue"). The activation gate is a single
+  // env-var; with it unset the legacy 256 ETH/epoch ceiling applies. With it set + fork
+  // epoch reached + beacon-state queue heads populated and the exit queue ahead of the
+  // consolidation queue, exits draw from idle consolidation churn for an effective uplift
+  // of up to ~688 ETH/epoch. See ADR-0002.
+  describe('EIP-8080 exit-via-consolidation-queue gating', () => {
+    // mainnet-scale inputs lifted from the post-Electra delegation test above
+    const mainnetUnfinalized = BigNumber.from('1000000000000000000000000'); // 1,000,000 ETH
+    const exitChurnGwei = BigNumber.from('256000000000'); // 256 ETH in Gwei (legacy cap)
+    const consolidationChurnGwei = BigNumber.from('432000000000'); // typical mainnet leftover
+
+    beforeEach(() => {
+      jest.spyOn(validatorsStorage, 'getActiveValidatorsCount').mockReturnValue(1_600_000);
+      jest.spyOn(validatorsStorage, 'getChurnLimit').mockReturnValue(8);
+      jest.spyOn(validatorsStorage, 'getMaxExitEpoch').mockReturnValue('252030');
+    });
+
+    it('env unset + queue state populated → still legacy formula (env is the master switch)', () => {
+      // Even with full beacon data and exit queue ahead, missing env keeps legacy.
+      jest.spyOn(validatorsStorage, 'getExitChurnPerEpochGwei').mockReturnValue(exitChurnGwei);
+      jest.spyOn(validatorsStorage, 'getConsolidationChurnPerEpochGwei').mockReturnValue(consolidationChurnGwei);
+      jest.spyOn(validatorsStorage, 'getEarliestExitEpoch').mockReturnValue('600000');
+      jest.spyOn(validatorsStorage, 'getEarliestConsolidationEpoch').mockReturnValue('500000');
+      jest.spyOn(configService, 'get').mockImplementation(() => null as never);
+
+      const days = service.calculateRequestTimeSimple(mainnetUnfinalized);
+      expect(days).toBe(22);
+    });
+
+    it('env set + currentEpoch < forkEpoch → legacy (chain has not activated yet)', () => {
+      jest.spyOn(validatorsStorage, 'getExitChurnPerEpochGwei').mockReturnValue(exitChurnGwei);
+      jest.spyOn(validatorsStorage, 'getConsolidationChurnPerEpochGwei').mockReturnValue(consolidationChurnGwei);
+      jest.spyOn(validatorsStorage, 'getEarliestExitEpoch').mockReturnValue('600000');
+      jest.spyOn(validatorsStorage, 'getEarliestConsolidationEpoch').mockReturnValue('500000');
+      // currentEpoch is 252025; fork epoch in the far future → legacy.
+      jest
+        .spyOn(configService, 'get')
+        .mockImplementation((key) => (key === 'EIP_8080_FORK_EPOCH' ? (9_999_999 as never) : (null as never)));
+
+      const days = service.calculateRequestTimeSimple(mainnetUnfinalized);
+      expect(days).toBe(22);
+    });
+
+    it('env set + post-fork + queue state missing → legacy (defensive null check)', () => {
+      // Validators job hasn't run an EIP-8080-aware tick yet. Storage returns null for the
+      // queue-state pair; the helper must fall back to legacy rather than NPE.
+      jest.spyOn(validatorsStorage, 'getExitChurnPerEpochGwei').mockReturnValue(null);
+      jest.spyOn(validatorsStorage, 'getConsolidationChurnPerEpochGwei').mockReturnValue(null);
+      jest.spyOn(validatorsStorage, 'getEarliestExitEpoch').mockReturnValue(null);
+      jest.spyOn(validatorsStorage, 'getEarliestConsolidationEpoch').mockReturnValue(null);
+      jest
+        .spyOn(configService, 'get')
+        .mockImplementation((key) => (key === 'EIP_8080_FORK_EPOCH' ? (1 as never) : (null as never)));
+
+      const days = service.calculateRequestTimeSimple(mainnetUnfinalized);
+      expect(days).toBe(22);
+    });
+
+    it('env set + post-fork + consolidation queue ahead → legacy (EIP-8080 branch does not fire)', () => {
+      jest.spyOn(validatorsStorage, 'getExitChurnPerEpochGwei').mockReturnValue(exitChurnGwei);
+      jest.spyOn(validatorsStorage, 'getConsolidationChurnPerEpochGwei').mockReturnValue(consolidationChurnGwei);
+      jest.spyOn(validatorsStorage, 'getEarliestExitEpoch').mockReturnValue('500000');
+      jest.spyOn(validatorsStorage, 'getEarliestConsolidationEpoch').mockReturnValue('600000');
+      jest
+        .spyOn(configService, 'get')
+        .mockImplementation((key) => (key === 'EIP_8080_FORK_EPOCH' ? (1 as never) : (null as never)));
+
+      const days = service.calculateRequestTimeSimple(mainnetUnfinalized);
+      expect(days).toBe(22);
+    });
+
+    it('env set + post-fork + exit queue ahead → uplift, estimate strictly shorter than legacy', () => {
+      // Effective exit churn = 256 + 432 × 3/2 = 904 ETH/epoch. At 1M ETH unfinalized:
+      //   lidoQueueInEpoch = 1_000_000e18 / 904e18 = 1106 (BigNumber integer div)
+      //   potentialExitEpoch = 252030 + 1106 + 1041 = 254177
+      //   waitingTime = (254177 - 252025) * 12 * 32 / 86400 = 826368 / 86400 = 9
+      //   (BigNumber.div is integer division — drops the fractional 0.56 BEFORE Math.round)
+      jest.spyOn(validatorsStorage, 'getExitChurnPerEpochGwei').mockReturnValue(exitChurnGwei);
+      jest.spyOn(validatorsStorage, 'getConsolidationChurnPerEpochGwei').mockReturnValue(consolidationChurnGwei);
+      jest.spyOn(validatorsStorage, 'getEarliestExitEpoch').mockReturnValue('600000');
+      jest.spyOn(validatorsStorage, 'getEarliestConsolidationEpoch').mockReturnValue('500000');
+      jest
+        .spyOn(configService, 'get')
+        .mockImplementation((key) => (key === 'EIP_8080_FORK_EPOCH' ? (1 as never) : (null as never)));
+
+      const days = service.calculateRequestTimeSimple(mainnetUnfinalized);
+      // Crucially: less than the legacy 22, demonstrating uplift fires.
+      expect(days).toBeLessThan(22);
+      // Pin the exact value so a future regression in the uplift math is caught.
+      expect(days).toBe(9);
+    });
+
+    it('env set + post-fork + exit queue ahead → exitValidators-case frame is also earlier than legacy', async () => {
+      jest.spyOn(validatorsStorage, 'getFrameBalances').mockReturnValue({});
+      jest.spyOn(validatorsStorage, 'getExitChurnPerEpochGwei').mockReturnValue(exitChurnGwei);
+      jest.spyOn(validatorsStorage, 'getConsolidationChurnPerEpochGwei').mockReturnValue(consolidationChurnGwei);
+      jest.spyOn(validatorsStorage, 'getEarliestExitEpoch').mockReturnValue('600000');
+      jest.spyOn(validatorsStorage, 'getEarliestConsolidationEpoch').mockReturnValue('500000');
+
+      // Legacy first (env unset)
+      jest.spyOn(configService, 'get').mockImplementation(() => null as never);
+      const legacyResult = await service.calculateWithdrawalFrame({
+        unfinalized: BigNumber.from('100000007748958196602737138'),
+        buffer: BigNumber.from('0'),
+        vaultsBalance: BigNumber.from('0'),
+        requestTimestamp: lockedSystemTimestamp,
+        latestEpoch: '312321',
+      });
+
+      // EIP-8080 path
+      jest
+        .spyOn(configService, 'get')
+        .mockImplementation((key) => (key === 'EIP_8080_FORK_EPOCH' ? (1 as never) : (null as never)));
+      const upliftedResult = await service.calculateWithdrawalFrame({
+        unfinalized: BigNumber.from('100000007748958196602737138'),
+        buffer: BigNumber.from('0'),
+        vaultsBalance: BigNumber.from('0'),
+        requestTimestamp: lockedSystemTimestamp,
+        latestEpoch: '312321',
+      });
+
+      expect(legacyResult.type).toBe(WaitingTimeCalculationType.exitValidators);
+      expect(upliftedResult.type).toBe(WaitingTimeCalculationType.exitValidators);
+      expect(upliftedResult.frame).toBeLessThan(legacyResult.frame);
     });
   });
 });

--- a/src/waiting-time/waiting-time.service.ts
+++ b/src/waiting-time/waiting-time.service.ts
@@ -11,12 +11,14 @@ import {
 import { LOGGER_PROVIDER, LoggerService } from 'common/logger';
 import { GenesisTimeService, SECONDS_PER_SLOT, SLOTS_PER_EPOCH } from 'common/genesis-time';
 import { PrometheusService } from 'common/prometheus';
+import { ConfigService } from 'common/config';
 
 import { GAP_AFTER_REPORT, MIN_ACTIVATION_BALANCE, WITHDRAWAL_BUNKER_DELAY_FRAMES } from './waiting-time.constants';
 import {
   validateTimeResponseWithFallback,
   calculateUnfinalizedEthToRequestId,
   calculateFrameByValidatorBalances,
+  computeEffectiveExitChurnPerEpochGwei,
 } from './utils';
 import { transformToRequestDto } from './dto';
 import {
@@ -45,7 +47,50 @@ export class WaitingTimeService {
     protected readonly queueInfo: QueueInfoStorageService,
     protected readonly prometheusService: PrometheusService,
     protected readonly blockStateCache: BlockStateCacheService,
+    protected readonly configService: ConfigService,
   ) {}
+
+  // Returns exit-side churn capacity in WEI per epoch. Single source of truth for both
+  // exit-validator-case formulas. Decision tree:
+  //   1. If EIP_8080_FORK_EPOCH env is unset → legacy single-queue formula.
+  //   2. If currentEpoch < forkEpoch → legacy (chain hasn't activated EIP-8080 yet —
+  //      applying the new model would over-promise users, the unsafe direction).
+  //   3. If beacon-state queue heads or consolidation churn aren't populated yet
+  //      (validators job hasn't completed an EIP-8080-aware tick) → legacy.
+  //   4. Else → effective exit churn per `computeEffectiveExitChurnPerEpochGwei`,
+  //      converted from Gwei to wei.
+  protected getExitChurnPerEpochWei(): BigNumber {
+    const churnLimit = this.validators.getChurnLimit();
+    const legacyExitChurnWei = MIN_ACTIVATION_BALANCE.mul(Math.floor(churnLimit));
+
+    const forkEpoch = this.configService.get('EIP_8080_FORK_EPOCH');
+    if (forkEpoch == null) return legacyExitChurnWei;
+    if (this.genesisTimeService.getCurrentEpoch() < forkEpoch) return legacyExitChurnWei;
+
+    const exitChurnGwei = this.validators.getExitChurnPerEpochGwei();
+    const consolidationChurnGwei = this.validators.getConsolidationChurnPerEpochGwei();
+    const earliestExitEpoch = this.validators.getEarliestExitEpoch();
+    const earliestConsolidationEpoch = this.validators.getEarliestConsolidationEpoch();
+    if (
+      exitChurnGwei == null ||
+      consolidationChurnGwei == null ||
+      earliestExitEpoch == null ||
+      earliestConsolidationEpoch == null
+    ) {
+      return legacyExitChurnWei;
+    }
+
+    const effectiveGwei = computeEffectiveExitChurnPerEpochGwei({
+      isExitViaConsolidationActive: true,
+      earliestExitEpoch: BigNumber.from(earliestExitEpoch),
+      earliestConsolidationEpoch: BigNumber.from(earliestConsolidationEpoch),
+      exitChurnPerEpochGwei: exitChurnGwei,
+      consolidationChurnPerEpochGwei: consolidationChurnGwei,
+    });
+
+    // 1 ETH = 1e9 Gwei = 1e18 wei → wei = gwei × 1e9.
+    return effectiveGwei.mul(BigNumber.from('1000000000'));
+  }
 
   // preparing all needed number for calculation withdrawal time
   public async getWaitingTimeInfo(args: GetWaitingTimeInfoV2Args): Promise<GetWaitingTimeInfoV2Result> {
@@ -265,15 +310,15 @@ export class WaitingTimeService {
     latestEpoch: string,
     rewardsAvailableForWithdrawals: BigNumber,
   ): Promise<number | null> {
-    const churnLimit = this.validators.getChurnLimit();
     const epochPerFrame = this.contractConfig.getEpochsPerFrame();
     const epochsPerFrameVEBO = this.contractConfig.getEpochsPerFrameVEBO();
     const rewardsPerEpoch = rewardsAvailableForWithdrawals.div(epochPerFrame);
 
-    // ETH released by validator exits per epoch. Post-Electra churn limit is balance-based and
-    // capped at 256 ETH/epoch by the protocol; multiplying by 32 ETH is a unit identity that
-    // converts the storage's "32-ETH-equivalent count" representation back to wei.
-    const exitChurnEthPerEpoch = MIN_ACTIVATION_BALANCE.mul(Math.floor(churnLimit));
+    // ETH released by validator exits per epoch. Pre-EIP-8080: post-Electra balance-based
+    // churn capped at 256 ETH/epoch. Post-EIP-8080 (when env-flag is on, fork epoch
+    // reached, and queue state is populated): exits also draw from idle consolidation
+    // churn, lifting the effective ceiling up to ~688 ETH/epoch. See ADR-0002.
+    const exitChurnEthPerEpoch = this.getExitChurnPerEpochWei();
     const exitChurnEthPerVEBOFrame = exitChurnEthPerEpoch.mul(epochsPerFrameVEBO);
 
     // VEBO cap is governance-set in whole ETH per VEBO frame. Whichever is smaller — the
@@ -478,11 +523,12 @@ export class WaitingTimeService {
   public calculateRequestTimeSimple(unfinalizedETH: BigNumber): number {
     const currentEpoch = this.genesisTimeService.getCurrentEpoch();
     const maxExitEpoch = this.getMaxExitEpoch();
-    // post-Electra balance-based churn (capped at 256 ETH/epoch); MIN_ACTIVATION_BALANCE × churnLimit
-    // is a unit identity that yields ETH-per-epoch exit capacity in wei
-    const churnLimit = this.validators.getChurnLimit();
+    // Effective exit-churn per epoch in wei. Routes through getExitChurnPerEpochWei so the
+    // EIP-8080 uplift (consolidation-queue routing) applies symmetrically with the
+    // VEBO-aware path; behaviour is unchanged when the feature flag is off.
+    const exitChurnPerEpochWei = this.getExitChurnPerEpochWei();
 
-    const lidoQueueInEpoch = unfinalizedETH.div(MIN_ACTIVATION_BALANCE.mul(Math.floor(churnLimit)));
+    const lidoQueueInEpoch = unfinalizedETH.div(exitChurnPerEpochWei);
     const sweepingMean = this.validators.getSweepMeanEpochs();
     const potentialExitEpoch = BigNumber.from(maxExitEpoch).add(lidoQueueInEpoch).add(sweepingMean);
 


### PR DESCRIPTION
## Summary

Models [EIP-8080 "Let exits use the consolidation queue"](https://eips.ethereum.org/EIPS/eip-8080) in the `exitValidators` waiting-time case. Behaviour is gated on a new `EIP_8080_FORK_EPOCH` env var; **default is legacy 256 ETH/epoch single-queue ceiling**. Once the fork is announced and activated on mainnet, operators set the env var per environment to enable the up-to-~2.5× exit-throughput uplift (~256 → up to ~688 ETH/epoch when the consolidation queue is idle).

## What changes

- **Pure CL change.** No EL/RPC/contract surface touched.
- New util `computeEffectiveExitChurnPerEpochGwei` (8 unit tests, pinning EIP's `× 2/3` weak-subjectivity factor and the "256 → 688" motivation example).
- Validators job reads `earliest_exit_epoch` / `earliest_consolidation_epoch` from beacon state (same streaming-pick path as sweep state — no new outbound URL surface).
- Validators storage gains exit/consolidation per-epoch churn budgets in Gwei plus the two queue heads. Disk cache format extended 6→10 positions (writer+reader moved in lockstep; old caches reject on length mismatch and self-heal next tick).
- `WaitingTimeService` derives effective exit-side churn through a single helper with a 4-step fallback gate. Both `calculateFrameExitValidatorsCaseWithVEBO` and `calculateRequestTimeSimple` delegate to it, so behaviour is symmetric.

## Why this shape

**Direction-of-error matters.** Applying EIP-8080 logic before the fork is live → over-promises users (estimate is shorter than chain can actually deliver) → unsafe. Not applying it after fork is live → under-promises → safe. So:

- Default = legacy → safe pre-fork.
- Activation = explicit env var → operator-controlled, single-config flip per environment.
- Validators-job not yet populated → defensive null-guard → legacy → safe during cold start.

Decision tree inside `getExitChurnPerEpochWei`:

1. `EIP_8080_FORK_EPOCH` unset → legacy formula.
2. `currentEpoch < forkEpoch` → legacy (chain hasn't activated yet).
3. Beacon-state queue heads / Gwei churn budgets not populated → legacy (cold-start guard).
4. Else → `computeEffectiveExitChurnPerEpochGwei`, converted Gwei → wei.

## Activation plan (separate, config-only PR)

1. Wait for the fork epoch to be announced on mainnet/testnets.
2. Set `EIP_8080_FORK_EPOCH=<epoch>` per environment — Hoodi first, mainnet last (after the fork has actually happened on mainnet).
3. Add `wq_eip_8080_active{}` and `wq_effective_exit_churn_eth_per_epoch` Prometheus gauges for dashboards.

## Test plan

- [x] `yarn jest` — 87 / 87 pass (existing 79 + 8 new util tests + 5 new gating tests, with overlap counted once).
- [x] `npx tsc --noEmit` — clean.
- [x] `yarn lint` — clean (4 pre-existing warnings unrelated to this PR).
- [ ] Smoke on Hoodi with `EIP_8080_FORK_EPOCH=` (unset): legacy estimates unchanged from current.
- [ ] Smoke on Hoodi with `EIP_8080_FORK_EPOCH=<some past epoch>` after deploy: `validators-info` exposes the new fields populated; `exitValidators`-case estimate drops in the same blockState scenario vs legacy.
- [ ] Verify validators disk cache regenerates cleanly on first boot after deploy (length-mismatch path, 6 → 10).


## Files changed

11 modified, 2 new (385 insertions, 23 deletions).

| Area | Files |
|---|---|
| EIP-8080 util + tests | `src/waiting-time/utils/compute-effective-exit-churn.{ts,spec.ts}`, `src/waiting-time/utils/index.ts`, `src/jobs/validators/utils/get-churn-limit.ts` |
| Beacon-state read | `src/common/consensus-provider/consensus-provider.types.ts`, `src/common/consensus-provider/consensus-client.service.ts`, `src/jobs/validators/validators.service.ts` |
| Storage + disk cache | `src/storage/validators/validators.service.ts`, `src/storage/validators/validators-cache.service.ts` |
| Env + wiring | `src/common/config/env.validation.ts`, `sample.env`, `src/waiting-time/waiting-time.service.ts`, `src/waiting-time/waiting-time.service.spec.ts` |
