### PR TITLE
feat: restart on secrets file rotation

### DIFF
--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './sanitize-error';

--- a/src/common/errors/sanitize-error.spec.ts
+++ b/src/common/errors/sanitize-error.spec.ts
@@ -1,0 +1,134 @@
+import { sanitizeError, SanitizedError } from 'common/errors';
+
+// ---------------------------------------------------------------------------
+// sanitizeError
+// ---------------------------------------------------------------------------
+
+describe('sanitizeError', () => {
+  // -------------------------------------------------------------------------
+  // Error instance
+  // -------------------------------------------------------------------------
+
+  it('returns name, message, and stack for a plain Error', () => {
+    const err = new Error('something went wrong');
+    const result = sanitizeError(err);
+
+    expect(result.name).toBe('Error');
+    expect(result.message).toBe('something went wrong');
+    expect(typeof result.stack).toBe('string');
+  });
+
+  it('preserves the subclass name for TypeError', () => {
+    const err = new TypeError('bad type');
+    const result = sanitizeError(err);
+    expect(result.name).toBe('TypeError');
+    expect(result.message).toBe('bad type');
+  });
+
+  it('preserves the subclass name for RangeError', () => {
+    const err = new RangeError('out of range');
+    const result = sanitizeError(err);
+    expect(result.name).toBe('RangeError');
+  });
+
+  it('preserves the name of a custom Error subclass', () => {
+    class NetworkError extends Error {
+      constructor(msg: string) {
+        super(msg);
+        this.name = 'NetworkError';
+      }
+    }
+    const err = new NetworkError('timeout');
+    const result = sanitizeError(err);
+    expect(result.name).toBe('NetworkError');
+    expect(result.message).toBe('timeout');
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-Error types
+  // -------------------------------------------------------------------------
+
+  it('wraps a string with name NonError', () => {
+    const result = sanitizeError('oops');
+    expect(result.name).toBe('NonError');
+    expect(result.message).toBe('oops');
+    expect(result.stack).toBeUndefined();
+  });
+
+  it('wraps a plain object via JSON.stringify', () => {
+    const result = sanitizeError({ code: 404, detail: 'not found' });
+    expect(result.name).toBe('NonError');
+    expect(result.message).toBe('{"code":404,"detail":"not found"}');
+  });
+
+  it('wraps null', () => {
+    const result = sanitizeError(null);
+    expect(result.name).toBe('NonError');
+    expect(result.message).toBe('null');
+  });
+
+  it('wraps undefined as the string "undefined"', () => {
+    const result = sanitizeError(undefined);
+    expect(result.name).toBe('NonError');
+    expect(result.message).toBe('undefined');
+  });
+
+  it('wraps a number', () => {
+    const result = sanitizeError(42);
+    expect(result.name).toBe('NonError');
+    expect(result.message).toBe('42');
+  });
+
+  it('wraps a boolean', () => {
+    const result = sanitizeError(false);
+    expect(result.name).toBe('NonError');
+    expect(result.message).toBe('false');
+  });
+
+  // -------------------------------------------------------------------------
+  // No extra properties leak through
+  // -------------------------------------------------------------------------
+
+  it('does not include extra properties from an Error with extra fields', () => {
+    const err = new Error('fail') as Error & {
+      authorization?: string;
+      headers?: object;
+    };
+    err.authorization = 'Bearer secret-token';
+    err.headers = { 'x-api-key': 'supersecret' };
+
+    const result = sanitizeError(err) as unknown as Record<string, unknown>;
+
+    expect(Object.keys(result).sort()).toEqual(['message', 'name', 'stack'].sort());
+    expect(result['authorization']).toBeUndefined();
+    expect(result['headers']).toBeUndefined();
+  });
+
+  it('does not include extra properties from a plain object', () => {
+    const result = sanitizeError({
+      sensitiveField: 'supersecret',
+      code: 500,
+    }) as unknown as Record<string, unknown>;
+
+    // Result is a SanitizedError shape — no raw keys from the input object
+    expect(Object.keys(result).sort()).toEqual(['message', 'name'].sort());
+  });
+
+  // -------------------------------------------------------------------------
+  // Return type shape
+  // -------------------------------------------------------------------------
+
+  it('always returns name and message as strings, regardless of input', () => {
+    const inputs: unknown[] = [new Error('e'), 'str', 42, null, undefined, {}, []];
+    for (const input of inputs) {
+      const result = sanitizeError(input);
+      expect(typeof result.name).toBe('string');
+      expect(typeof result.message).toBe('string');
+    }
+  });
+
+  it('satisfies the SanitizedError interface', () => {
+    const result: SanitizedError = sanitizeError(new Error('test'));
+    expect(result).toBeDefined();
+  });
+});

--- a/src/common/errors/sanitize-error.ts
+++ b/src/common/errors/sanitize-error.ts
@@ -1,0 +1,24 @@
+// Narrow an unknown error to a flat, safe-to-log shape.
+//
+// Logging a raw error object can leak request headers (e.g. Authorization),
+// fetch config, or other sensitive metadata that some libraries attach.
+// We keep only the message, name, and stack — enough for debugging, nothing
+// that contains secrets.
+
+export interface SanitizedError {
+  name: string;
+  message: string;
+  stack?: string;
+}
+
+export const sanitizeError = (error: unknown): SanitizedError => {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message, stack: error.stack };
+  }
+  if (typeof error === 'string') {
+    return { name: 'NonError', message: error };
+  }
+  // JSON.stringify(undefined) returns undefined (the value), which would violate
+  // the SanitizedError contract — fall back to String() for unstringifiable inputs.
+  return { name: 'NonError', message: JSON.stringify(error) ?? String(error) };
+};

--- a/src/common/shutdown/index.ts
+++ b/src/common/shutdown/index.ts
@@ -1,0 +1,1 @@
+export * from './secrets-rotation';

--- a/src/common/shutdown/secrets-rotation.spec.ts
+++ b/src/common/shutdown/secrets-rotation.spec.ts
@@ -1,0 +1,166 @@
+import { mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { LoggerService } from '@nestjs/common';
+
+import { registerSecretsRotationRestart } from './secrets-rotation';
+
+const CONTENT_V1 = 'export PROVIDER_URL="v1"\n';
+const CONTENT_V2 = 'export PROVIDER_URL="v2"\n';
+
+// Real timers + tight poll interval: fs.watchFile stat-polls the path, fake
+// timers would freeze it.
+const WATCH_INTERVAL_MS = 20;
+
+// Give fs.watchFile time to start before changing the file.
+// Otherwise, the test may miss the first update and become flaky.
+const waitForWatchToStart = async (): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, WATCH_INTERVAL_MS * 2));
+};
+
+const waitFor = async (assertion: () => void, timeoutMs = 5_000): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (Date.now() > deadline) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+};
+
+// Mirror the agent's atomic update: write a temp file, rename over the path (new inode).
+const atomicWrite = (path: string, content: string): void => {
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, content);
+  renameSync(tmp, path);
+};
+
+describe('registerSecretsRotationRestart', () => {
+  const logger: LoggerService = {
+    log: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  };
+
+  let dir: string;
+  let file: string;
+  let stopWatch: (() => void) | null = null;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'secrets-rotation-'));
+    file = join(dir, 'app');
+    process.env.SECRETS_FILE = file;
+  });
+
+  afterEach(() => {
+    stopWatch?.();
+    stopWatch = null;
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.SECRETS_FILE;
+    jest.clearAllMocks();
+  });
+
+  it('is a no-op when no secrets file is injected (default path absent)', () => {
+    delete process.env.SECRETS_FILE;
+    const close = jest.fn();
+    stopWatch = registerSecretsRotationRestart({ close }, logger, {
+      intervalMs: WATCH_INTERVAL_MS,
+    });
+    expect(logger.log).not.toHaveBeenCalled();
+  });
+
+  it('throws when SECRETS_FILE is explicitly set but unreadable', () => {
+    process.env.SECRETS_FILE = join(dir, 'nope');
+    const close = jest.fn();
+    expect(() => registerSecretsRotationRestart({ close }, logger)).toThrow();
+  });
+
+  it('closes the app and exits 0 when the file content changes (atomic rename)', async () => {
+    writeFileSync(file, CONTENT_V1);
+    const close = jest.fn().mockResolvedValue(undefined);
+    const exit = jest.fn();
+    stopWatch = registerSecretsRotationRestart({ close }, logger, {
+      intervalMs: WATCH_INTERVAL_MS,
+      exit,
+    });
+
+    await waitForWatchToStart();
+
+    atomicWrite(file, CONTENT_V2);
+    await waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('still exits 0 when close rejects', async () => {
+    writeFileSync(file, CONTENT_V1);
+    const close = jest.fn().mockRejectedValue(new Error('boom'));
+    const exit = jest.fn();
+    stopWatch = registerSecretsRotationRestart({ close }, logger, {
+      intervalMs: WATCH_INTERVAL_MS,
+      exit,
+    });
+
+    await waitForWatchToStart();
+
+    atomicWrite(file, CONTENT_V2);
+    await waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('force-exits when close hangs', async () => {
+    writeFileSync(file, CONTENT_V1);
+    const close = jest.fn().mockReturnValue(new Promise<void>(() => undefined));
+    const exit = jest.fn();
+    stopWatch = registerSecretsRotationRestart({ close }, logger, {
+      intervalMs: WATCH_INTERVAL_MS,
+      forceExitMs: 50,
+      exit,
+    });
+
+    await waitForWatchToStart();
+
+    atomicWrite(file, CONTENT_V2);
+    await waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('does not restart when the file is rewritten with identical content', async () => {
+    writeFileSync(file, CONTENT_V1);
+    const close = jest.fn();
+    const exit = jest.fn();
+    stopWatch = registerSecretsRotationRestart({ close }, logger, {
+      intervalMs: WATCH_INTERVAL_MS,
+      exit,
+    });
+
+    await waitForWatchToStart();
+
+    atomicWrite(file, CONTENT_V1);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(close).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('survives a delete+recreate window: keeps running, restarts on the new content', async () => {
+    writeFileSync(file, CONTENT_V1);
+    const close = jest.fn().mockResolvedValue(undefined);
+    const exit = jest.fn();
+    stopWatch = registerSecretsRotationRestart({ close }, logger, {
+      intervalMs: WATCH_INTERVAL_MS,
+      exit,
+    });
+
+    await waitForWatchToStart();
+
+    rmSync(file);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(exit).not.toHaveBeenCalled();
+
+    writeFileSync(file, CONTENT_V2);
+    await waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/common/shutdown/secrets-rotation.ts
+++ b/src/common/shutdown/secrets-rotation.ts
@@ -1,0 +1,98 @@
+import { readFileSync, unwatchFile, watchFile } from 'node:fs';
+import { LoggerService } from '@nestjs/common';
+import { sanitizeError } from 'common/errors';
+
+// If graceful close hangs (stuck DB pool, external requests), force-exit:
+// staying alive with stale secrets is worse than a hard restart.
+const FORCE_EXIT_TIMEOUT_MS = 10_000;
+const DEFAULT_SECRETS_FILE = '/vault/secrets/app';
+const POLL_INTERVAL_MS = 10_000;
+
+interface Closeable {
+  close: () => Promise<void>;
+}
+
+interface SecretsRotationOptions {
+  intervalMs?: number;
+  forceExitMs?: number;
+  exit?: (code: number) => void;
+}
+
+/**
+ * OpenBao rotation restart. Secrets arrive as an env-export file that the
+ * chart's container command sources before exec; the agent sidecar keeps it
+ * fresh via atomic rename but has no signal path into this container (no
+ * shared PID namespace), so the app must detect rotation itself: poll the file
+ * BY PATH (fs.watchFile — inotify would attach to the old inode and go silent
+ * after the first rename) and restart-by-exit on a content change: close the
+ * Nest app gracefully and exit 0; `restartPolicy: Always` brings it back up and
+ * the startup command re-sources the refreshed file.
+ *
+ * Path from SECRETS_FILE, default /vault/secrets/app. File absent at the
+ * default path = no injector (local dev) → no-op; SECRETS_FILE set but
+ * unreadable = broken deployment → throw. Returns a stop function (tests).
+ */
+export function registerSecretsRotationRestart(
+  app: Closeable,
+  logger: LoggerService,
+  options: SecretsRotationOptions = {},
+): () => void {
+  const {
+    intervalMs = POLL_INTERVAL_MS,
+    forceExitMs = FORCE_EXIT_TIMEOUT_MS,
+    exit = (code) => process.exit(code),
+  } = options;
+  const path = process.env.SECRETS_FILE ?? DEFAULT_SECRETS_FILE;
+
+  let lastContent: string;
+  try {
+    lastContent = readFileSync(path, 'utf8');
+  } catch (error: unknown) {
+    if (process.env.SECRETS_FILE) throw error;
+    return () => undefined;
+  }
+  logger.log?.(`Watching secrets file ${path} for rotation`);
+
+  let restarting = false;
+  const restart = (): void => {
+    if (restarting) return;
+    restarting = true;
+    logger.log?.('Secrets file changed: rotated credentials, restarting to pick up new values');
+
+    const forceExitTimer = setTimeout(() => {
+      logger.error?.(`Graceful close timed out after ${forceExitMs}ms, forcing exit`);
+      exit(0);
+    }, forceExitMs);
+
+    app
+      .close()
+      .catch((error: unknown) => {
+        logger.error?.('Graceful close on secrets rotation failed', sanitizeError(error));
+      })
+      .finally(() => {
+        clearTimeout(forceExitTimer);
+        exit(0);
+      });
+  };
+
+  const listener = (): void => {
+    let raw: string;
+    try {
+      raw = readFileSync(path, 'utf8');
+    } catch (error: unknown) {
+      // Transient (sidecar restart / delete+recreate window): retry ourselves —
+      // watchFile won't re-fire for a stat it has already seen, so a failed read
+      // here would otherwise strand the process on stale creds until the NEXT
+      // rotation.
+      logger.warn?.(`Secrets file ${path} unreadable, retrying`, sanitizeError(error));
+      setTimeout(listener, Math.min(intervalMs, 5_000)).unref();
+      return;
+    }
+    if (raw === lastContent) return;
+    lastContent = raw;
+    restart();
+  };
+
+  watchFile(path, { interval: intervalMs }, listener).unref();
+  return () => unwatchFile(path, listener);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,12 @@
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe, VersioningType } from '@nestjs/common';
+import { ShutdownSignal, ValidationPipe, VersioningType } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
 import { SWAGGER_URL } from 'http/common/swagger';
 import { ConfigService } from 'common/config';
+import { registerSecretsRotationRestart } from 'common/shutdown';
 import { AppModule, APP_DESCRIPTION, APP_NAME, APP_VERSION } from 'app';
 import { satanizer, commonPatterns } from '@lidofinance/satanizer';
 import { useContainer } from 'class-validator';
@@ -31,7 +32,8 @@ async function bootstrap() {
   app.enableVersioning({ type: VersioningType.URI });
 
   // logger
-  app.useLogger(app.get(LOGGER_PROVIDER));
+  const logger = app.get(LOGGER_PROVIDER);
+  app.useLogger(logger);
 
   // sentry
   const mask = satanizer([...commonPatterns, ...secrets]);
@@ -79,6 +81,9 @@ async function bootstrap() {
   SwaggerModule.setup(SWAGGER_URL, app, swaggerDocument);
 
   setupServiceUnavailableMiddleware(app, configService);
+
+  app.enableShutdownHooks([ShutdownSignal.SIGTERM, ShutdownSignal.SIGINT]);
+  registerSecretsRotationRestart(app, logger);
 
   // app
   await app.listen(appPort, '0.0.0.0');

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,6 +82,8 @@ async function bootstrap() {
 
   setupServiceUnavailableMiddleware(app, configService);
 
+  // TERM/INT are the orchestrator's normal stop signals; OpenBao secret-rotation
+  // restarts are file-based (no signal path from the injector sidecar).
   app.enableShutdownHooks([ShutdownSignal.SIGTERM, ShutdownSignal.SIGINT]);
   registerSecretsRotationRestart(app, logger);
 


### PR DESCRIPTION
### Description

Adds application restart when OpenBao secrets are rotated.

The app watches the injected secrets file for content changes, gracefully shuts down, and exits so Kubernetes can restart the container with the updated environment variables.

### Checklist:

- [x] Checked the changes locally.
- [ ] Created / updated analytics events.
- [ ] Created / updated the technical documentation (README.md / [docs](https://docs.lido.fi/) / etc.).
- [ ] Affects / requires changes in other services (Matomo / Sentry / CloudFlare / etc.).
